### PR TITLE
Extending endstate corrections to solvated systems

### DIFF
--- a/endstate_rew/neq.py
+++ b/endstate_rew/neq.py
@@ -5,7 +5,7 @@ from openmm import unit
 from tqdm import tqdm
 from typing import Tuple
 
-from endstate_rew.constant import distance_unit, temperature, check_implementation
+from endstate_rew.constant import distance_unit, temperature
 from endstate_rew.system import get_positions
 
 

--- a/endstate_rew/neq.py
+++ b/endstate_rew/neq.py
@@ -6,7 +6,7 @@ from tqdm import tqdm
 from typing import Tuple
 
 from endstate_rew.constant import distance_unit, temperature, check_implementation
-from endstate_rew.system import _seed_velocities, _get_masses, get_positions
+from endstate_rew.system import get_positions
 
 from openmm import OpenMMException
 
@@ -43,12 +43,7 @@ def perform_switching(
         sim.context.setPositions(x)
 
         # reseed velocities
-
-        try:
-            sim.context.setVelocitiesToTemperature(temperature)
-        except OpenMMException:
-            # NOTE: FIXME: for now this is done manually
-            sim.context.setVelocities(_seed_velocities(_get_masses(sim.system)))
+        sim.context.setVelocitiesToTemperature(temperature)
 
         # initialize work
         w = 0.0

--- a/endstate_rew/neq.py
+++ b/endstate_rew/neq.py
@@ -8,8 +8,6 @@ from typing import Tuple
 from endstate_rew.constant import distance_unit, temperature, check_implementation
 from endstate_rew.system import get_positions
 
-from openmm import OpenMMException
-
 
 def perform_switching(
     sim, lambdas: list, samples: list, nr_of_switches: int = 50, save_traj: bool = False

--- a/endstate_rew/neq.py
+++ b/endstate_rew/neq.py
@@ -14,8 +14,6 @@ def perform_switching(
 ) -> Tuple[list, list]:
     """performs NEQ switching using the lambda sheme passed from randomly dranw samples"""
 
-    implementation, platform = check_implementation()
-
     # list  of work values
     ws = []
     # list of conformations
@@ -62,7 +60,6 @@ def perform_switching(
             u_before = sim.context.getState(getEnergy=True).getPotentialEnergy()
             # add to accumulated work
             w += (u_now - u_before).value_in_unit(unit.kilojoule_per_mole)
-        ws.append(w)
         if save_traj:
             endstate_samples.append(get_positions(sim))
     return np.array(ws) * unit.kilojoule_per_mole, endstate_samples

--- a/endstate_rew/system.py
+++ b/endstate_rew/system.py
@@ -210,10 +210,10 @@ def _initialize_simulation(
     sim.context.setPositions(molecule.conformers[conf_id])
     # NOTE: FIXME: minimizing the energy of the interpolating potential leeds to very high energies,
     # for now avoiding call to minimizer
-    print("Minimizing ...")
     u_1 = sim.context.getState(getEnergy=True).getPotentialEnergy()
 
     if minimize is True:
+        print("Minimizing ...")
         sim.minimizeEnergy(maxIterations=100)
     u_2 = sim.context.getState(getEnergy=True).getPotentialEnergy()
     print(f"before min: {u_1}; after min: {u_2}")

--- a/endstate_rew/system.py
+++ b/endstate_rew/system.py
@@ -5,7 +5,6 @@ from os import path
 import openmm as mm
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField
-from openmm import unit
 from openmm.app import (
     CharmmParameterSet,
     CharmmPsfFile,
@@ -17,8 +16,6 @@ from tqdm import tqdm
 
 from endstate_rew.constant import (
     collision_rate,
-    kBT,
-    speed_unit,
     stepsize,
     temperature,
     zinc_systems,

--- a/endstate_rew/system.py
+++ b/endstate_rew/system.py
@@ -2,7 +2,6 @@ import pickle
 from glob import glob
 from os import path
 
-import numpy as np
 import openmm as mm
 from openff.toolkit.topology import Molecule
 from openff.toolkit.typing.engines.smirnoff import ForceField

--- a/endstate_rew/tests/test_neq.py
+++ b/endstate_rew/tests/test_neq.py
@@ -6,8 +6,6 @@ import pytest
 from endstate_rew.neq import perform_switching
 from endstate_rew.system import (
     _get_hipen_data,
-    _get_masses,
-    _seed_velocities,
     create_openff_system,
     generate_molecule,
     initialize_simulation_with_charmmff,
@@ -95,20 +93,6 @@ def test_mass_list():
     assert np.allclose(
         m_list.value_in_unit(unit.daltons), masses.value_in_unit(unit.daltons)
     )
-
-
-def test_seed_velocities():
-
-    # test that manual velocity seeding works
-    # openff
-    molecule = generate_molecule(forcefield="openff", smiles="ClCCOCCCl")
-    system, _ = create_openff_system(molecule)
-    _seed_velocities(_get_masses(system))
-
-    # charmmff
-    molecule = generate_molecule(forcefield="charmmff", name="ZINC00079729")
-    system, _ = create_openff_system(molecule)
-    _seed_velocities(_get_masses(system))
 
 
 @pytest.mark.parametrize(

--- a/endstate_rew/tests/test_neq.py
+++ b/endstate_rew/tests/test_neq.py
@@ -80,21 +80,6 @@ def load_endstate_system_and_samples_openff(
     return sim, samples_mm, samples_qml
 
 
-def test_mass_list():
-
-    molecule = generate_molecule(forcefield="openff", smiles="ClCCOCCCl")
-    system, _ = create_openff_system(molecule)
-
-    # make sure that mass list generated from system and molecuel are the same
-    m_list = _get_masses(system)
-    masses = np.array([a.mass / unit.dalton for a in molecule.atoms]) * unit.daltons
-    print(m_list)
-    print(masses)
-    assert np.allclose(
-        m_list.value_in_unit(unit.daltons), masses.value_in_unit(unit.daltons)
-    )
-
-
 @pytest.mark.parametrize(
     "ff, dW_for, dW_rev",
     [

--- a/scripts/sampling.py
+++ b/scripts/sampling.py
@@ -1,7 +1,8 @@
 # general imports
 import os
-import pickle
 import sys
+from openmm.app import DCDReporter, PDBFile
+
 
 import numpy as np
 import torch
@@ -29,9 +30,9 @@ else:
     name = "2cle"
     smiles = "ClCCOCCCl"
 ###################
-ff = "charmmff" #"openff" #"charmmff"  # openff
+ff = "charmmff"  # "openff" #"charmmff"  # openff
 n_samples = 5_000
-n_steps_per_sample = 1_000
+n_steps_per_sample = 5
 n_lambdas = 11
 platform = "CUDA"
 ###################
@@ -64,7 +65,7 @@ print(f"saving to: {w_dir}")
 # select a random conformation
 from random import randint
 
-conf_id = randint(0, molecule.n_conformers - 1)
+conf_id = 2  # randint(0, molecule.n_conformers - 1)
 print(f"select conf_id: {conf_id}")
 ###################
 # initialize simulation depending on ff keyword
@@ -76,30 +77,32 @@ if ff == "openff":
     )
 elif ff == "charmmff":
     sim = initialize_simulation_with_charmmff(
-        molecule, zinc_id=name, conf_id=conf_id
+        molecule, zinc_id=name, conf_id=conf_id, minimize=False
     )
 else:
     raise RuntimeError("Either openff or charmmff. Abort.")
 ###################
+PDBFile.writeFile(
+    sim.topology, molecule.conformers[conf_id], file=open(f"{w_dir}/{name}.pdb", "w")
+)
 # perform lambda protocoll
-for lamb in lambs:
+for lamb in [1.0]:
+    trajectory_file = f"{w_dir}/{name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_{lamb:.4f}.dcd"
     print(f"{lamb=}")
     # set lambda
     sim.context.setParameter("lambda_interpolate", lamb)
+    # add reporter
+    sim.reporters.append(
+        DCDReporter(
+            trajectory_file,
+            n_steps_per_sample,
+        )
+    )
+
     # set coordinates
     sim.context.setPositions(molecule.conformers[conf_id])
     # collect samples
     samples = generate_samples(
         sim, n_samples=n_samples, n_steps_per_sample=n_steps_per_sample
     )
-    # save samples
-    pickle.dump(
-        samples,
-        open(
-            f"{w_dir}/{name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_{lamb:.4f}.pickle",
-            "wb+",
-        ),
-    )
-    print(
-        f"traj dump to: {w_dir}/{name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_{lamb:.4f}.pickle"
-    )
+    print(f"traj saved to: {trajectory_file}")

--- a/scripts/sampling_additional_charmm_systems.py
+++ b/scripts/sampling_additional_charmm_systems.py
@@ -113,10 +113,13 @@ else:
 chains = list(psf.topology.chains())
 ml_atoms = [atom.index for atom in chains[0].atoms()]
 print(f"{ml_atoms=}")
+
+#####################
 potential = MLPotential("ani2x")
 ml_system = potential.createMixedSystem(
     psf.topology, mm_system, ml_atoms, interpolate=True
 )
+#####################
 
 integrator = mm.LangevinIntegrator(temperature, collision_rate, stepsize)
 platform = mm.Platform.getPlatformByName(platform)

--- a/scripts/sampling_additional_charmm_systems.py
+++ b/scripts/sampling_additional_charmm_systems.py
@@ -59,7 +59,7 @@ assert env in ("waterbox", "vacuum")
 ###########################################
 potential = MLPotential("ani2x")
 
-base = f"/data/shared/projects/endstate_rew/jctc_data/{system_name}/"
+output_base = f"/data/shared/projects/endstate_rew/jctc_data/{system_name}/"
 parameter_base = f"{package_path}/data/jctc_data"
 ###################
 ff = "charmmff"  # "openff" #"charmmff"  # openff
@@ -69,8 +69,8 @@ n_lambdas = 2
 platform = "CUDA"
 ###################
 ###################
-os.makedirs(f"{base}/sampling_{ff}/run{run_id:0>2d}", exist_ok=True)
-print(f"saving to {base}/sampling_{ff}/run{run_id:0>2d}")
+os.makedirs(f"{output_base}/sampling_{ff}/run{run_id:0>2d}", exist_ok=True)
+print(f"saving to {output_base}/sampling_{ff}/run{run_id:0>2d}")
 print(f"{system_name=}")
 print(f"{run_id=}")
 print(f"{ff=}")
@@ -130,7 +130,7 @@ sim = Simulation(psf.topology, ml_system, integrator, platform=platform)
 # perform lambda protocoll
 for lamb in lambs:
     print(f"{lamb=}")
-    trajectory_file = f"{base}/sampling_{ff}/run{run_id:0>2d}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_{lamb:.4f}_{env}.dcd"
+    trajectory_file = f"{output_base}/sampling_{ff}/run{run_id:0>2d}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_{lamb:.4f}_{env}.dcd"
 
     print(f"Trajectory saved to: {trajectory_file}")
     # set lambda

--- a/scripts/sampling_additional_charmm_systems.py
+++ b/scripts/sampling_additional_charmm_systems.py
@@ -70,7 +70,7 @@ platform = "CUDA"
 ###################
 ###################
 os.makedirs(f"{base}/sampling_{ff}/run{run_id:0>2d}", exist_ok=True)
-print("saving to {base}/sampling_{ff}/run{run_id:0>2d}")
+print(f"saving to {base}/sampling_{ff}/run{run_id:0>2d}")
 print(f"{system_name=}")
 print(f"{run_id=}")
 print(f"{ff=}")

--- a/scripts/switching_additional_charmm_systems.py
+++ b/scripts/switching_additional_charmm_systems.py
@@ -78,8 +78,8 @@ qml_to_mm_traj_filename = f"{base}/switching_{ff}/{system_name}_samples_{n_sampl
 print(f"{ff=}")
 print(f"{system_name=}")
 
-mm_to_qml_filename = f"{base}/switching_{ff}/{system_name}_neq_ws_from_mm_to_qml_{nr_of_switches}_{switching_length}.pickle"
-qml_to_mm_filename = f"{base}/switching_{ff}/{system_name}_neq_ws_from_qml_to_mm_{nr_of_switches}_{switching_length}.pickle"
+mm_to_qml_filename = f"{base}/switching_{ff}/{system_name}_neq_ws_from_mm_to_qml_{nr_of_switches}_{switching_length}_{env}.pickle"
+qml_to_mm_filename = f"{base}/switching_{ff}/{system_name}_neq_ws_from_qml_to_mm_{nr_of_switches}_{switching_length}_{env}.pickle"
 
 if path.isfile(mm_to_qml_filename) and path.isfile(qml_to_mm_filename):
     print("All work values have already been calculated.")

--- a/scripts/switching_additional_charmm_systems.py
+++ b/scripts/switching_additional_charmm_systems.py
@@ -1,0 +1,220 @@
+# general imports
+import pickle
+import sys
+import os
+from os import path
+import numpy as np
+import torch
+from endstate_rew.neq import perform_switching
+from openmm.app import (
+    PME,
+    CharmmParameterSet,
+    CharmmPsfFile,
+    NoCutoff,
+    PDBFile,
+    Simulation,
+)
+from openmmml import MLPotential
+from endstate_rew.constant import collision_rate, jctc_systems, stepsize, temperature
+from glob import glob
+import json
+from openmm import unit
+import endstate_rew
+import openmm as mm
+import mdtraj
+
+package_path = endstate_rew.__path__[0]
+
+
+def read_box(psf, filename):
+    try:
+        sysinfo = json.load(open(filename, "r"))
+        boxlx, boxly, boxlz = map(float, sysinfo["dimensions"][:3])
+    except:
+        for line in open(filename, "r"):
+            segments = line.split("=")
+            if segments[0].strip() == "BOXLX":
+                boxlx = float(segments[1])
+            if segments[0].strip() == "BOXLY":
+                boxly = float(segments[1])
+            if segments[0].strip() == "BOXLZ":
+                boxlz = float(segments[1])
+    psf.setBox(boxlx * unit.angstroms, boxly * unit.angstroms, boxlz * unit.angstroms)
+    return psf
+
+
+num_threads = 2
+torch.set_num_threads(num_threads)
+env = "vacuum"  # waterbox
+assert env in ("waterbox", "vacuum")
+###########################################################################################
+# define run
+print("Simulating jctc system")
+system_id = int(sys.argv[1])
+system_name = jctc_systems[system_id]
+# choose ff and working directory
+ff = "charmmff"  # openff
+w_dir = f"/data/shared/projects/endstate_rew/{system_name}/"
+platform = "CUDA"
+###########################################
+potential = MLPotential("ani2x")
+
+base = f"/data/shared/projects/endstate_rew/jctc_data/{system_name}/"
+parameter_base = f"{package_path}/data/jctc_data"
+###################
+# equilibrium samples
+n_samples = 5_000
+n_steps_per_sample = 1_000
+#############
+# NEQ
+switching_length = 5_001
+nr_of_switches = 500
+#############
+save_traj = True
+mm_to_qml_traj_filename = f"{w_dir}/switching_{ff}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_qml_endstate_nr_samples_{nr_of_switches}_switching_length_{switching_length}_{env}.pickle"
+qml_to_mm_traj_filename = f"{w_dir}/switching_{ff}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_mm_endstate_nr_samples_{nr_of_switches}_switching_length_{switching_length}_{env}.pickle"
+#############
+
+print(f"{ff=}")
+print(f"{system_name=}")
+
+mm_to_qml_filename = f"{w_dir}/switching_{ff}/{system_name}_neq_ws_from_mm_to_qml_{nr_of_switches}_{switching_length}.pickle"
+qml_to_mm_filename = f"{w_dir}/switching_{ff}/{system_name}_neq_ws_from_qml_to_mm_{nr_of_switches}_{switching_length}.pickle"
+
+if path.isfile(mm_to_qml_filename) and path.isfile(qml_to_mm_filename):
+    print("All work values have already been calculated.")
+    sys.exit()
+
+
+# create folder
+os.makedirs(f"{w_dir}/switching_{ff}", exist_ok=True)
+print(f"Generate directory: {w_dir}/switching_{ff}")
+
+###########################################################################################
+###########################################################################################
+# generate mol
+# generate simulation
+if env == "vacuum":
+    top = f"{parameter_base}/{system_name}/charmm-gui/openmm/vac.psf"
+    psf = CharmmPsfFile(top)
+    pdb = PDBFile(f"{parameter_base}/{system_name}/charmm-gui/openmm/vac.pdb")
+elif env == "waterbox":
+    top = f"{parameter_base}/{system_name}/charmm-gui/openmm/step3_input.psf"
+    psf = CharmmPsfFile(top)
+    pdb = PDBFile(f"{parameter_base}/{system_name}/charmm-gui/openmm/step3_input.pdb")
+else:
+    raise RuntimeError()
+
+params = CharmmParameterSet(
+    f"{parameter_base}/{system_name}/charmm-gui/unk/unk.rtf",
+    f"{parameter_base}/{system_name}/charmm-gui/unk/unk.prm",
+    f"{parameter_base}/toppar/top_all36_cgenff.rtf",
+    f"{parameter_base}/toppar/par_all36_cgenff.prm",
+    f"{parameter_base}/toppar/toppar_water_ions.str",
+)
+
+if env == "vacuum":
+    mm_system = psf.createSystem(params, nonbondedMethod=NoCutoff)
+elif env == "waterbox":
+    psf = read_box(psf, f"{parameter_base}/{system_name}/charmm-gui/input.config.dat")
+    mm_system = psf.createSystem(params, nonbondedMethod=PME)
+else:
+    raise RuntimeError()
+
+chains = list(psf.topology.chains())
+ml_atoms = [atom.index for atom in chains[0].atoms()]
+print(f"{ml_atoms=}")
+potential = MLPotential("ani2x")
+ml_system = potential.createMixedSystem(
+    psf.topology, mm_system, ml_atoms, interpolate=True
+)
+
+integrator = mm.LangevinIntegrator(temperature, collision_rate, stepsize)
+platform = mm.Platform.getPlatformByName(platform)
+sim = Simulation(psf.topology, ml_system, integrator, platform=platform)
+###########################################################################################
+# load samples for lambda=0. , the mm endstate
+mm_samples = []
+mm_sample_files = glob(
+    f"/data/shared/projects/endstate_rew/jctc_data/{system_name}/sampling_{ff}/run*/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_0.0000_{env}.dcd"
+)
+nr_of_runs = len(mm_sample_files)
+
+for samples in mm_sample_files:
+    mm_samples.extend(
+        mdtraj.load_dcd(
+            samples,
+            top=top,
+        ).xyz
+        * unit.nanometer
+    )
+
+assert len(mm_samples) == nr_of_runs * n_samples
+###########################################################################################
+# load samples for lambda=1. , the qml endstate
+qml_samples = []
+qml_sample_files = glob(
+    f"/data/shared/projects/endstate_rew/jctc_data/{system_name}/sampling_{ff}/run*/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_1.0000_{env}.dcd"
+)
+nr_of_runs = len(qml_sample_files)
+
+for samples in qml_sample_files:
+    qml_samples.extend(
+        mdtraj.load_dcd(
+            samples,
+            top=top,
+        ).xyz
+        * unit.nanometer
+    )
+
+assert len(qml_samples) == nr_of_runs * n_samples
+###########################################################################################
+# MM endstate
+# perform switching only if file does not already exist
+if not path.isfile(mm_to_qml_filename):
+    # define lambda space
+    lambs = np.linspace(0, 1, switching_length)
+    # perform NEQ from MM to QML
+    ws_from_mm_to_qml, mm_to_qml_samples = perform_switching(
+        sim,
+        lambdas=lambs,
+        samples=mm_samples,
+        nr_of_switches=nr_of_switches,
+        save_traj=save_traj,
+    )
+    # dump work values
+    print(ws_from_mm_to_qml)
+    pickle.dump(ws_from_mm_to_qml, open(mm_to_qml_filename, "wb"))
+
+    if save_traj:
+        # save qml endstate samples
+        pickle.dump(mm_to_qml_samples, open(mm_to_qml_traj_filename, "wb+"))
+        print(f"traj dump to: {mm_to_qml_traj_filename}")
+else:
+    print(f"Already calculated: {mm_to_qml_filename}")
+sys.exit()
+
+###########################################################################################
+# QML endstate
+# # perform switching only if file does not already exist
+if not path.isfile(qml_to_mm_filename):
+    # define lambda space
+    lambs = np.linspace(1, 0, switching_length)
+    # perform NEQ from QML to MM
+    ws_from_qml_to_mm, qml_to_mm_samples = perform_switching(
+        sim,
+        lambdas=lambs,
+        samples=qml_samples,
+        nr_of_switches=nr_of_switches,
+        save_traj=save_traj,
+    )
+    # dump work values
+    pickle.dump(ws_from_qml_to_mm, open(qml_to_mm_filename, "wb+"))
+    print(ws_from_qml_to_mm)
+
+    if save_traj:
+        # save MM endstate samples
+        pickle.dump(qml_to_mm_samples, open(qml_to_mm_traj_filename, "wb+"))
+        print(f"traj dump to: {qml_to_mm_traj_filename}")
+else:
+    print(f"Already calculated: {qml_to_mm_filename}")

--- a/scripts/switching_additional_charmm_systems.py
+++ b/scripts/switching_additional_charmm_systems.py
@@ -135,7 +135,7 @@ sim = Simulation(psf.topology, ml_system, integrator, platform=platform)
 # load samples for lambda=0. , the mm endstate
 mm_samples = []
 mm_sample_files = glob(
-    f"/data/shared/projects/endstate_rew/jctc_data/{system_name}/sampling_{ff}/run*/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_0.0000_{env}.dcd"
+    f"{base}/sampling_{ff}/run*/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_0.0000_{env}.dcd"
 )
 nr_of_runs = len(mm_sample_files)
 
@@ -153,7 +153,7 @@ assert len(mm_samples) == nr_of_runs * n_samples
 # load samples for lambda=1. , the qml endstate
 qml_samples = []
 qml_sample_files = glob(
-    f"/data/shared/projects/endstate_rew/jctc_data/{system_name}/sampling_{ff}/run*/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_1.0000_{env}.dcd"
+    f"{base}/sampling_{ff}/run*/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_1.0000_{env}.dcd"
 )
 nr_of_runs = len(qml_sample_files)
 

--- a/scripts/switching_additional_charmm_systems.py
+++ b/scripts/switching_additional_charmm_systems.py
@@ -12,7 +12,6 @@ from openmm.app import (
     CharmmPsfFile,
     NoCutoff,
     PDBFile,
-    DCDReporter,
     Simulation,
 )
 from openmmml import MLPotential
@@ -59,7 +58,7 @@ platform = "CUDA"
 ###########################################
 potential = MLPotential("ani2x")
 
-base = f"/data/shared/projects/endstate_rew/jctc_data/{system_name}/"
+output_base = f"/data/shared/projects/endstate_rew/jctc_data/{system_name}/"
 parameter_base = f"{package_path}/data/jctc_data"
 ###################
 # equilibrium samples
@@ -71,15 +70,15 @@ switching_length = 5_001
 nr_of_switches = 500
 #############
 save_traj = True
-mm_to_qml_traj_filename = f"{base}/switching_{ff}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_qml_endstate_nr_samples_{nr_of_switches}_switching_length_{switching_length}_{env}.pickle"
-qml_to_mm_traj_filename = f"{base}/switching_{ff}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_mm_endstate_nr_samples_{nr_of_switches}_switching_length_{switching_length}_{env}.pickle"
+mm_to_qml_traj_filename = f"{output_base}/switching_{ff}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_qml_endstate_nr_samples_{nr_of_switches}_switching_length_{switching_length}_{env}.pickle"
+qml_to_mm_traj_filename = f"{output_base}/switching_{ff}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_mm_endstate_nr_samples_{nr_of_switches}_switching_length_{switching_length}_{env}.pickle"
 #############
 
 print(f"{ff=}")
 print(f"{system_name=}")
 
-mm_to_qml_filename = f"{base}/switching_{ff}/{system_name}_neq_ws_from_mm_to_qml_{nr_of_switches}_{switching_length}_{env}.pickle"
-qml_to_mm_filename = f"{base}/switching_{ff}/{system_name}_neq_ws_from_qml_to_mm_{nr_of_switches}_{switching_length}_{env}.pickle"
+mm_to_qml_filename = f"{output_base}/switching_{ff}/{system_name}_neq_ws_from_mm_to_qml_{nr_of_switches}_{switching_length}_{env}.pickle"
+qml_to_mm_filename = f"{output_base}/switching_{ff}/{system_name}_neq_ws_from_qml_to_mm_{nr_of_switches}_{switching_length}_{env}.pickle"
 
 if path.isfile(mm_to_qml_filename) and path.isfile(qml_to_mm_filename):
     print("All work values have already been calculated.")
@@ -87,8 +86,8 @@ if path.isfile(mm_to_qml_filename) and path.isfile(qml_to_mm_filename):
 
 
 # create folder
-os.makedirs(f"{base}/switching_{ff}", exist_ok=True)
-print(f"Generate directory: {base}/switching_{ff}")
+os.makedirs(f"{output_base}/switching_{ff}", exist_ok=True)
+print(f"Generate directory: {output_base}/switching_{ff}")
 
 ###########################################################################################
 ###########################################################################################
@@ -136,7 +135,7 @@ sim = Simulation(psf.topology, ml_system, integrator, platform=platform)
 # load samples for lambda=0. , the mm endstate
 mm_samples = []
 mm_sample_files = glob(
-    f"{base}/sampling_{ff}/run*/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_0.0000_{env}.dcd"
+    f"{output_base}/sampling_{ff}/run*/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_0.0000_{env}.dcd"
 )
 nr_of_runs = len(mm_sample_files)
 
@@ -154,7 +153,7 @@ assert len(mm_samples) == nr_of_runs * n_samples
 # load samples for lambda=1. , the qml endstate
 qml_samples = []
 qml_sample_files = glob(
-    f"{base}/sampling_{ff}/run*/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_1.0000_{env}.dcd"
+    f"{output_base}/sampling_{ff}/run*/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_1.0000_{env}.dcd"
 )
 nr_of_runs = len(qml_sample_files)
 

--- a/scripts/switching_additional_charmm_systems.py
+++ b/scripts/switching_additional_charmm_systems.py
@@ -132,13 +132,6 @@ ml_system = potential.createMixedSystem(
 integrator = mm.LangevinIntegrator(temperature, collision_rate, stepsize)
 platform = mm.Platform.getPlatformByName(platform)
 sim = Simulation(psf.topology, ml_system, integrator, platform=platform)
-# sim.reporters.append(
-#     DCDReporter(
-#         "save_everything.dcd",
-#         1,
-#     )
-# )
-
 ###########################################################################################
 # load samples for lambda=0. , the mm endstate
 mm_samples = []

--- a/scripts/switching_additional_charmm_systems.py
+++ b/scripts/switching_additional_charmm_systems.py
@@ -54,7 +54,6 @@ system_id = int(sys.argv[1])
 system_name = jctc_systems[system_id]
 # choose ff and working directory
 ff = "charmmff"  # openff
-w_dir = f"/data/shared/projects/endstate_rew/{system_name}/"
 platform = "CUDA"
 ###########################################
 potential = MLPotential("ani2x")
@@ -71,15 +70,15 @@ switching_length = 5_001
 nr_of_switches = 500
 #############
 save_traj = True
-mm_to_qml_traj_filename = f"{w_dir}/switching_{ff}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_qml_endstate_nr_samples_{nr_of_switches}_switching_length_{switching_length}_{env}.pickle"
-qml_to_mm_traj_filename = f"{w_dir}/switching_{ff}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_mm_endstate_nr_samples_{nr_of_switches}_switching_length_{switching_length}_{env}.pickle"
+mm_to_qml_traj_filename = f"{base}/switching_{ff}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_qml_endstate_nr_samples_{nr_of_switches}_switching_length_{switching_length}_{env}.pickle"
+qml_to_mm_traj_filename = f"{base}/switching_{ff}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_mm_endstate_nr_samples_{nr_of_switches}_switching_length_{switching_length}_{env}.pickle"
 #############
 
 print(f"{ff=}")
 print(f"{system_name=}")
 
-mm_to_qml_filename = f"{w_dir}/switching_{ff}/{system_name}_neq_ws_from_mm_to_qml_{nr_of_switches}_{switching_length}.pickle"
-qml_to_mm_filename = f"{w_dir}/switching_{ff}/{system_name}_neq_ws_from_qml_to_mm_{nr_of_switches}_{switching_length}.pickle"
+mm_to_qml_filename = f"{base}/switching_{ff}/{system_name}_neq_ws_from_mm_to_qml_{nr_of_switches}_{switching_length}.pickle"
+qml_to_mm_filename = f"{base}/switching_{ff}/{system_name}_neq_ws_from_qml_to_mm_{nr_of_switches}_{switching_length}.pickle"
 
 if path.isfile(mm_to_qml_filename) and path.isfile(qml_to_mm_filename):
     print("All work values have already been calculated.")
@@ -87,8 +86,8 @@ if path.isfile(mm_to_qml_filename) and path.isfile(qml_to_mm_filename):
 
 
 # create folder
-os.makedirs(f"{w_dir}/switching_{ff}", exist_ok=True)
-print(f"Generate directory: {w_dir}/switching_{ff}")
+os.makedirs(f"{base}/switching_{ff}", exist_ok=True)
+print(f"Generate directory: {base}/switching_{ff}")
 
 ###########################################################################################
 ###########################################################################################
@@ -192,7 +191,6 @@ if not path.isfile(mm_to_qml_filename):
         print(f"traj dump to: {mm_to_qml_traj_filename}")
 else:
     print(f"Already calculated: {mm_to_qml_filename}")
-sys.exit()
 
 ###########################################################################################
 # QML endstate


### PR DESCRIPTION
## Description
Endstate corrections are  necessary on all nodes of a thermodynamic cycle. To evaluate the accuracy of the QML/MM approach we select a set of molecules for which absolute solvation free energies are available and perform endstate reweighting.


## Todos
  - [x] Adding systems from https://pubs.acs.org/doi/10.1021/ct401118k
  - [x] Extending pipeline for waterbox endstate reweighting 

## Status
- [ ] Ready to go