### PR TITLE
NCMC sampling scheme with free energy estimate

### DIFF
--- a/endstate_correction/ncmc.py
+++ b/endstate_correction/ncmc.py
@@ -1,17 +1,25 @@
 # implement everything related to NCMC
+from endstate_correction.neq import perform_switching
+from endstate_correction.equ import generate_samples
+from openmm.app import Simulation
+import numpy as np
 
-def perform_ncmc_simulations():
-    
+
+def perform_ncmc_simulations(sim: Simulation):
+
     # initiallize sampling from initial conformation
-    
+
     # samples for 1 ns
-    
-    # (START): use sample after 1 ns to initialize a NEQ switching protocoll (with propagation and perturbation kernal) 
+    sample = generate_samples(sim, n_samples=1, n_steps_per_sample=1_000_000)
+    # (START): use sample after 1 ns to initialize a NEQ switching protocoll (with propagation and perturbation kernal)
     # from a source level of theory to a target level of theory and collect work values
-    
+    lambdas = np.linspace(0, 1, 5_000)
+    w, sample = perform_switching(
+        sim, lambdas, sample, nr_of_switches=1, save_traj=True
+    )
+    # both are lists with only one element
+    w = w[0], sample = sample[0]
     # use work value in metropolis criteria to either acceptor or reject the new conformation at the target level of theory
-    
     # if accepted: this new conformation is now used with the target level of theory to continue sampling (for 1ps), then (START) again
-    
-    # if rejected: neither the conformation nor the work value are used, the velocity reversed initial conformation is used to continue sampling (for 1ps), then (START) again  
-    
+
+    # if rejected: neither the conformation nor the work value are used, the velocity reversed initial conformation is used to continue sampling (for 1ps), then (START) again

--- a/endstate_correction/ncmc.py
+++ b/endstate_correction/ncmc.py
@@ -1,1 +1,17 @@
 # implement everything related to NCMC
+
+def perform_ncmc_simulations():
+    
+    # initiallize sampling from initial conformation
+    
+    # samples for 1 ns
+    
+    # (START): use sample after 1 ns to initialize a NEQ switching protocoll (with propagation and perturbation kernal) 
+    # from a source level of theory to a target level of theory and collect work values
+    
+    # use work value in metropolis criteria to either acceptor or reject the new conformation at the target level of theory
+    
+    # if accepted: this new conformation is now used with the target level of theory to continue sampling (for 1ps), then (START) again
+    
+    # if rejected: neither the conformation nor the work value are used, the velocity reversed initial conformation is used to continue sampling (for 1ps), then (START) again  
+    

--- a/endstate_correction/ncmc.py
+++ b/endstate_correction/ncmc.py
@@ -1,0 +1,1 @@
+# implement everything related to NCMC


### PR DESCRIPTION
## Description
## Description

Instead of using NEQ to calculate the free energy, we perform NEQ trial moves between the level of theries to 1) record the work values (if accepted), but also (2) to enable a faster sampling of the conformational space since conformations obtained with the different level of theories can be used to seed further equilibrium samples.

## Todos
  - [ ] add  NCMC trial moves
  - [ ] record NEQ 
  
## Questions
- [ ] figure out if we need to bias the MC moves (this might be necessary if we realize that the probability of accepting a move from MM to QML is different than the other way around, so if p(MM|QML) != p(QML|MM). If this is the case things will become a bit more complicated.

## Status
- [ ] Ready to go