### PR TITLE
Additional options for openmm system

### DIFF
--- a/endstate_correction/neq.py
+++ b/endstate_correction/neq.py
@@ -15,7 +15,7 @@ import openmm
 
 
 def perform_switching(
-    sim, lambdas: list, samples: list, nr_of_switches: int = 50, save_traj: bool = False
+    sim, lambdas: list, samples: list, nr_of_switches: int = 50, save_traj: bool = True
 ) -> Tuple[list, list]:
     """performs NEQ switching using the lambda sheme passed from randomly dranw samples"""
 

--- a/endstate_correction/system.py
+++ b/endstate_correction/system.py
@@ -10,6 +10,7 @@ from openmm.app import (
     CharmmCrdFile,
     NoCutoff,
     Simulation,
+    PDBFile,
 )
 from openmmml import MLPotential
 from tqdm import tqdm
@@ -82,6 +83,7 @@ def create_charmm_system(
     ml_atoms: list,
     r_off: int = 1.0,
     r_on: int = 0,
+    rigidWater: bool = True,
 ) -> Simulation:
     """Generate an openMM simulation object using CHARMM topology and parameter files
 

--- a/endstate_correction/system.py
+++ b/endstate_correction/system.py
@@ -83,7 +83,7 @@ def create_charmm_system(
     ml_atoms: list,
     r_off: int = 1.0,
     r_on: int = 0,
-    rigidWater: bool = True,
+    implementation: str = check_implementation()[0]
 ) -> Simulation:
     """Generate an openMM simulation object using CHARMM topology and parameter files
 
@@ -124,7 +124,11 @@ def create_charmm_system(
     #####################
     potential = MLPotential("ani2x")
     ml_system = potential.createMixedSystem(
-        psf.topology, mm_system, ml_atoms, interpolate=True
+        psf.topology,
+        mm_system,
+        ml_atoms,
+        interpolate=True,
+        implementation=implementation,
     )
     #####################
 

--- a/endstate_correction/system.py
+++ b/endstate_correction/system.py
@@ -2,7 +2,7 @@
 import json
 
 import openmm as mm
-from openmm import unit
+from openmm import unit, MonteCarloBarostat
 from openmm.app import (
     PME,
     CharmmParameterSet,
@@ -83,7 +83,8 @@ def create_charmm_system(
     ml_atoms: list,
     r_off: int = 1.0,
     r_on: int = 0,
-    implementation: str = check_implementation()[0]
+    implementation: str = check_implementation()[0],
+    npt: bool = False,
 ) -> Simulation:
     """Generate an openMM simulation object using CHARMM topology and parameter files
 
@@ -117,6 +118,7 @@ def create_charmm_system(
             nonbondedMethod=PME,
             nonbondedCutoff=r_off * unit.nanometers,
             switchDistance=r_on * unit.nanometers,
+            temperature=temperature
         )
 
     print(f"{ml_atoms=}")
@@ -131,6 +133,10 @@ def create_charmm_system(
         implementation=implementation,
     )
     #####################
+
+    if npt:
+        barostat = MonteCarloBarostat(1.0 * unit.bar, temperature)
+        ml_system.addForce(barostat)
 
     integrator = mm.LangevinIntegrator(temperature, collision_rate, stepsize)
     platform = mm.Platform.getPlatformByName(platform)


### PR DESCRIPTION
There might be the need for setting some additional options, I will collect them in this PR

1. Option for avoiding constrained water (`rigidWater=False`) --> removed it again, hopefully it won't be necessary
2. Option to choose which implementation one wants to use, default is `nnpops` if available
3. Possibility to choose `npt` as an option (the default is still `nvt`)
4. I set the default temperature to 303.15 K (the default from CHARMM-GUI), we can also set it to 298.15 K (the default of openmm), or do you want to leave it at 300 K
5. I think we should add the `temperature` variable in `psf.createSystem` for creating the MM system because otherwise the default will be used (298.15 K)