### PR TITLE
Adjust switching protocol

### DIFF
--- a/endstate_correction/tests/test_endstate_correction.py
+++ b/endstate_correction/tests/test_endstate_correction.py
@@ -277,8 +277,32 @@ def test_each_protocol():
     assert len(r.dE_qml_to_mm) == 0
     assert len(r.W_mm_to_qml) == neq_protocol.nr_of_switches
     assert len(r.W_qml_to_mm) == 0
+    assert len(r.endstate_samples_mm_to_qml) == 0
+    assert len(r.endstate_samples_qml_to_mm) == 0
+    assert len(r.switching_traj_mm_to_qml) == 0
+    assert len(r.switching_traj_qml_to_mm) == 0
 
-    fep_protocol = Protocol(
+    neq_protocol = Protocol(
+        method="NEQ",
+        direction="unidirectional_reverse",
+        sim=sim,
+        trajectories=[mm_samples, qml_samples],
+        nr_of_switches=10,
+        neq_switching_length=50,
+    )
+
+    r = perform_endstate_correction(neq_protocol)
+    assert len(r.dE_mm_to_qml) == 0
+    assert len(r.dE_qml_to_mm) == 0
+    assert len(r.W_mm_to_qml) == 0
+    assert len(r.W_qml_to_mm) == neq_protocol.nr_of_switches
+    assert len(r.endstate_samples_mm_to_qml) == 0
+    assert len(r.endstate_samples_qml_to_mm) == 0
+    assert len(r.switching_traj_mm_to_qml) == 0
+    assert len(r.switching_traj_qml_to_mm) == 0
+    
+
+    neq_protocol = Protocol(
         sim=sim,
         method="NEQ",
         direction="bidirectional",
@@ -287,8 +311,36 @@ def test_each_protocol():
         neq_switching_length=50,
     )
 
-    r = perform_endstate_correction(fep_protocol)
+    r = perform_endstate_correction(neq_protocol)
     assert len(r.dE_mm_to_qml) == 0
     assert len(r.dE_qml_to_mm) == 0
     assert len(r.W_mm_to_qml) == neq_protocol.nr_of_switches
     assert len(r.W_qml_to_mm) == neq_protocol.nr_of_switches
+    assert len(r.endstate_samples_mm_to_qml) == 0
+    assert len(r.endstate_samples_qml_to_mm) == 0
+    assert len(r.switching_traj_mm_to_qml) == 0
+    assert len(r.switching_traj_qml_to_mm) == 0
+        
+    # test saving endstates and saving trajectory option
+    protocol = Protocol(
+        method="NEQ",
+        direction="bidirectional",
+        sim=sim,
+        trajectories=[mm_samples, qml_samples],
+        nr_of_switches=10,
+        neq_switching_length=50,
+        save_endstates = True,
+        save_trajs= True
+    )
+
+    r = perform_endstate_correction(protocol)
+    assert len(r.dE_mm_to_qml) == 0
+    assert len(r.dE_qml_to_mm) == 0
+    assert len(r.W_mm_to_qml) == protocol.nr_of_switches
+    assert len(r.W_qml_to_mm) == protocol.nr_of_switches   
+    assert len(r.endstate_samples_mm_to_qml) == protocol.nr_of_switches
+    assert len(r.endstate_samples_qml_to_mm) == protocol.nr_of_switches
+    assert len(r.switching_traj_mm_to_qml) == protocol.nr_of_switches
+    assert len(r.switching_traj_qml_to_mm) == protocol.nr_of_switches
+    assert len(r.switching_traj_mm_to_qml[0]) == protocol.neq_switching_length
+    assert len(r.switching_traj_qml_to_mm[0]) == protocol.neq_switching_length

--- a/endstate_correction/tests/test_neq.py
+++ b/endstate_correction/tests/test_neq.py
@@ -70,7 +70,7 @@ def test_switching():
     system_name = "ZINC00077329"
     print(f"{system_name=}")
 
-    # load simulation and samples for 2cle
+    # load simulation and samples for ZINC00077329
     sim, samples_mm, samples_qml = load_endstate_system_and_samples(
         system_name=system_name,
     )
@@ -79,7 +79,7 @@ def test_switching():
     # dU_rev = dU(x)_mm - dU(x)_qml
     lambs = np.linspace(0, 1, 2)
     print(lambs)
-    dE_list, _ = perform_switching(
+    dE_list, _, _ = perform_switching(
         sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1
     )
     assert np.isclose(
@@ -87,7 +87,7 @@ def test_switching():
     )
     lambs = np.linspace(1, 0, 2)
 
-    dE_list, _ = perform_switching(
+    dE_list, _, _ = perform_switching(
         sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1
     )
     print(dE_list)
@@ -98,26 +98,37 @@ def test_switching():
 
     # perform NEQ switching
     lambs = np.linspace(0, 1, 21)
-    dW_forw, _ = perform_switching(
+    dW_forw, _, _ = perform_switching(
         sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1
     )
     print(dW_forw)
 
     # perform NEQ switching
     lambs = np.linspace(0, 1, 101)
-    dW_forw, _ = perform_switching(
+    dW_forw, _, _ = perform_switching(
         sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1
     )
     print(dW_forw)
 
     # check return values
-    lambs = np.linspace(0, 1, 2)
-    list_1, list_2 = perform_switching(
-        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1, save_traj=False
+    lambs = np.linspace(0, 1, 3)
+    list_1, list_2, list_3 = perform_switching(
+        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1, save_endstates=False, save_trajs=False
     )
-    assert len(list_1) != 0 and len(list_2) == 0
+    assert len(list_1) == 1 and len(list_2) == 0 and len(list_3) == 0
 
-    list_1, list_2 = perform_switching(
-        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1, save_traj=True
+    list_1, list_2, list_3 = perform_switching(
+        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1, save_endstates=False, save_trajs=True
     )
-    assert len(list_1) != 0 and len(list_2) != 0
+
+    assert len(list_1) == 1 and len(list_2) == 0 and len(list_3) == 1 and len(list_3[0]) == 3
+
+    list_1, list_2, list_3 = perform_switching(
+        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1, save_endstates=True, save_trajs=False
+    )
+    assert len(list_1) == 1 and len(list_2) == 1 and len(list_3) == 0
+
+    list_1, list_2, list_3 = perform_switching(
+        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1, save_endstates=True, save_trajs=True
+    )
+    assert len(list_1) == 1 and len(list_2) == 1 and len(list_3) == 1 and len(list_3[0]) == 3

--- a/scripts/perform_correction_hipen.py
+++ b/scripts/perform_correction_hipen.py
@@ -1,0 +1,134 @@
+# general imports
+from endstate_correction.system import create_charmm_system, read_box
+from openmm.app import (
+    PME,
+    CharmmParameterSet,
+    CharmmPsfFile,
+    CharmmCrdFile,
+    PDBFile,
+)
+from endstate_correction.constant import zinc_systems, blacklist
+from endstate_correction.analysis import plot_endstate_correction_results
+import endstate_correction
+from endstate_correction.protocol import perform_endstate_correction, Protocol
+import mdtraj
+from openmm import unit
+import pickle, sys, os
+from endstate_correction.utils import convert_pickle_to_dcd_file
+
+########################################################
+########################################################
+# ------------------- set up system -------------------#
+package_path = endstate_correction.__path__[0]
+system_idx = int(sys.argv[1])
+system_name = zinc_systems[system_idx][0]
+
+if system_name in blacklist:
+    print('System in blacklist. Aborting.')
+    sys.exit()
+
+env = "vacuum"
+
+print(system_name)
+print(env)
+
+# define directory containing parameters
+parameter_base = f"{package_path}/data/hipen_data"
+# load the charmm specific files (psf, rtf, prm and str files)
+psf_file = f"{parameter_base}/{system_name}/{system_name}.psf"
+crd_file = f"{parameter_base}/{system_name}/{system_name}.crd"
+psf = CharmmPsfFile(psf_file)
+crd = CharmmCrdFile(crd_file)
+params = CharmmParameterSet(
+    f"{parameter_base}/top_all36_cgenff.rtf",
+    f"{parameter_base}/par_all36_cgenff.prm",
+    f"{parameter_base}/{system_name}/{system_name}.str",
+)
+# write pdb file
+with open("temp.pdb", "w") as outfile:
+    PDBFile.writeFile(psf.topology, crd.positions, outfile)
+
+# define region that should be treated with the qml
+chains = list(psf.topology.chains())
+ml_atoms = [atom.index for atom in chains[0].atoms()]
+# define system
+sim = create_charmm_system(psf=psf, parameters=params, env=env, ml_atoms=ml_atoms)
+
+########################################################
+########################################################
+# ------------------- load samples --------------------#
+n_samples = 5_000
+n_steps_per_sample = 1_000
+
+# define directory containing MM and QML sampling data
+traj_base =  f"/data/shared/projects/endstate_rew/{system_name}/sampling_charmmff/"
+
+# load MM samples
+mm_samples = []
+for i in range(1,4):
+    base = f"{traj_base}/run0{i}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_0.0000" 
+    # if needed, convert pickle file to dcd
+    #convert_pickle_to_dcd_file(f"{base}.pickle",psf_file, crd_file, f"{base}.dcd", "temp.pdb")
+    traj = mdtraj.load_dcd(
+            f"{base}.dcd",
+            top=psf_file,
+    )
+    mm_samples.extend(traj[1000:].xyz * unit.nanometer)  # NOTE: this is in nanometer!
+print(f'Initializing switch from {len(mm_samples)} MM samples')
+
+# load QML samples
+qml_samples = []
+for i in range(1,4):
+    base = f"{traj_base}/run0{i}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_1.0000"
+    # if needed, convert pickle file to dcd
+    #convert_pickle_to_dcd_file(f"{base}.pickle",psf_file, crd_file, f"{base}.dcd", "temp.pdb")
+    traj = mdtraj.load_dcd(
+            f"{base}.dcd",
+            top=psf_file,
+    )
+    qml_samples.extend(traj[1000:].xyz * unit.nanometer)  # NOTE: this is in nanometer!
+print(f'Initializing switch from {len(mm_samples)} QML samples')
+
+########################################################
+########################################################
+# ----------------- perform correction ----------------#
+
+# define the output directory
+output_base = f"/data/shared/projects/endstate_rew/{system_name}/switching_new/"
+os.makedirs(output_base, exist_ok=True)
+
+####################################################
+# ---------------- FEP protocol --------------------
+####################################################
+fep_protocol = Protocol(
+    method="FEP",
+    direction="bidirectional",
+    sim=sim,
+    trajectories=[mm_samples, qml_samples],
+    nr_of_switches=10 #2_000,
+)
+
+####################################################
+# ----------------- NEQ protocol -------------------
+####################################################
+neq_protocol = Protocol(
+    method="NEQ",
+    direction="bidirectional",
+    sim=sim,
+    trajectories=[mm_samples, qml_samples],
+    nr_of_switches=3, #500,
+    neq_switching_length=5, #_000,
+    save_endstates=True,
+    save_trajs=True
+)
+
+# perform correction
+r_fep = perform_endstate_correction(fep_protocol)
+r_neq = perform_endstate_correction(neq_protocol)
+
+# save fep and neq results in a pickle file
+pickle.dump((r_fep, r_neq), open(f"{output_base}/results.pickle", "wb"))
+
+# plot results
+plot_endstate_correction_results(system_name, r_fep, f"{output_base}/results_neq.png")
+plot_endstate_correction_results(system_name, r_neq, f"{output_base}/results_neq.png")


### PR DESCRIPTION
## Description
The switching protocol has been modified by adding options to save switching conformations (endstate conformations or full switching trajectories). Additionally, the option for performing a 'reverse' unidirectional FEP or NEQ protocol has been added. This PR also provides a script for performing FEP or NEQ for a HiPen system in vacuum.  

## Todos
  - [x] modify `neq.py` and `protocol.py`: add option to save switching trajectory or endstate conformations
  - [x] adjust tests
  - [x] add `perform_correction_hipen.py` script

## Status
- [x] Ready to go