### PR TITLE
Allow switches to start from NpT trajectories

### DIFF
--- a/endstate_correction/analysis.py
+++ b/endstate_correction/analysis.py
@@ -89,7 +89,6 @@ def plot_results_for_equilibrium_free_energy(
 def plot_endstate_correction_results(
     name: str, results: Results, filename: str = "plot.png"
 ):
-
     assert type(results) == Results
 
     multiple_results = 1
@@ -97,36 +96,36 @@ def plot_endstate_correction_results(
     print("#--------------- SUMMARY ---------------#")
     ##############################################
     # ---------------------- FEP ------------------
-    if results.dE_mm_to_qml.size:
+    if results.dE_reference_to_target.size:
         print(
-            f"Zwanzig's equation (from mm to qml): {exp(results.dE_mm_to_qml)['Delta_f']}"
+            f"Zwanzig's equation (from mm to qml): {exp(results.dE_reference_to_target)['Delta_f']}"
         )
         multiple_results += 1
-    if results.dE_qml_to_mm.size:
+    if results.dE_target_to_reference.size:
         print(
-            f"Zwanzig's equation (from qml to mm): {exp(results.dE_qml_to_mm)['Delta_f']}"
+            f"Zwanzig's equation (from qml to mm): {exp(results.dE_target_to_reference)['Delta_f']}"
         )
         multiple_results += 1
-    if results.dE_mm_to_qml.size and results.dE_qml_to_mm.size:
+    if results.dE_reference_to_target.size and results.dE_target_to_reference.size:
         print(
-            f"Zwanzig's equation bidirectional: {bar(results.dE_mm_to_qml, results.dE_qml_to_mm)['Delta_f']}"
+            f"Zwanzig's equation bidirectional: {bar(results.dE_reference_to_target, results.dE_target_to_reference)['Delta_f']}"
         )
         multiple_results += 1
     ##############################################
     # ---------------------- NEQ ------------------
-    if results.W_mm_to_qml.size:
+    if results.W_reference_to_target.size:
         print(
-            f"Jarzynski's equation (from mm to qml): {exp(results.W_mm_to_qml)['Delta_f']}"
+            f"Jarzynski's equation (from mm to qml): {exp(results.W_reference_to_target)['Delta_f']}"
         )
         multiple_results += 1
-    if results.W_qml_to_mm.size:
+    if results.W_target_to_reference.size:
         print(
-            f"Jarzynski's equation (from qml to mm): {exp(results.W_qml_to_mm)['Delta_f']}"
+            f"Jarzynski's equation (from qml to mm): {exp(results.W_target_to_reference)['Delta_f']}"
         )
         multiple_results += 1
-    if results.W_mm_to_qml.size and results.W_qml_to_mm.size:
+    if results.W_reference_to_target.size and results.W_target_to_reference.size:
         print(
-            f"Crooks' equation: {bar(results.W_mm_to_qml, results.W_qml_to_mm)['Delta_f']}"
+            f"Crooks' equation: {bar(results.W_reference_to_target, results.W_target_to_reference)['Delta_f']}"
         )
         multiple_results += 1
     ##############################################
@@ -175,44 +174,44 @@ def plot_endstate_correction_results(
         axis="x", style="sci", useOffset=True, scilimits=(0, 0)
     )
 
-    if results.W_mm_to_qml.size:
+    if results.W_reference_to_target.size:
         sns.histplot(
             ax=axs[ax_index],
             alpha=0.5,
-            data=results.W_mm_to_qml,
+            data=results.W_reference_to_target,
             kde=True,
             stat="density",
             label=r"W(MM$\rightarrow$QML)",
             color=c1,
         )
 
-    if results.dE_mm_to_qml.size:
+    if results.dE_reference_to_target.size:
         sns.histplot(
             ax=axs[ax_index],
             alpha=0.5,
-            data=results.dE_mm_to_qml,
+            data=results.dE_reference_to_target,
             kde=True,
             stat="density",
             label=r"$\Delta$E(MM$\rightarrow$QML)",
             color=c2,
         )
 
-    if results.W_qml_to_mm.size:
+    if results.W_target_to_reference.size:
         sns.histplot(
             ax=axs[ax_index],
             alpha=0.5,
-            data=results.W_qml_to_mm * -1,
+            data=results.W_target_to_reference * -1,
             kde=True,
             stat="density",
             label=r"W(QML$\rightarrow$MM)",
             color=c3,
         )
 
-    if results.dE_qml_to_mm.size:
+    if results.dE_target_to_reference.size:
         sns.histplot(
             ax=axs[ax_index],
             alpha=0.5,
-            data=results.dE_qml_to_mm * -1,
+            data=results.dE_target_to_reference * -1,
             kde=True,
             stat="density",
             label=r"$\Delta$E(QML$\rightarrow$MM)",
@@ -232,34 +231,34 @@ def plot_endstate_correction_results(
             ddG_list.append(ddG_equ)
             dddG_list.append(dddG_equ)
             names.append("Equilibrium")
-        if results.W_mm_to_qml.size and results.W_qml_to_mm.size:
+        if results.W_reference_to_target.size and results.W_target_to_reference.size:
             # Crooks' equation
             ddG, dddG = -1, -1
-            r = bar(results.W_mm_to_qml, results.W_qml_to_mm)
+            r = bar(results.W_reference_to_target, results.W_target_to_reference)
             ddG, dddG = r["Delta_f"], r["dDelta_f"]
             ddG_list.append(ddG)
             dddG_list.append(dddG)
             names.append("NEQ+Crooks")
-        if results.W_mm_to_qml.size:
+        if results.W_reference_to_target.size:
             # Jarzynski's equation
             ddG, dddG = -1, -1
-            r = exp(results.W_mm_to_qml)
+            r = exp(results.W_reference_to_target)
             ddG, dddG = r["Delta_f"], r["dDelta_f"]
             ddG_list.append(ddG)
             dddG_list.append(dddG)
             names.append("NEQ+Jazynski")
-        if results.dE_mm_to_qml.size and results.dE_qml_to_mm.size:
+        if results.dE_reference_to_target.size and results.dE_target_to_reference.size:
             # FEP + bar
             ddG, dddG = -1, -1
-            r = bar(results.dE_mm_to_qml, results.dE_qml_to_mm)
+            r = bar(results.dE_reference_to_target, results.dE_target_to_reference)
             ddG, dddG = r["Delta_f"], r["dDelta_f"]
             ddG_list.append(ddG)
             dddG_list.append(dddG)
             names.append("FEP+BAR")
-        if results.dE_mm_to_qml.size:
+        if results.dE_reference_to_target.size:
             # FEP + EXP
             ddG, dddG = -1, -1
-            r = exp(results.dE_mm_to_qml)
+            r = exp(results.dE_reference_to_target)
             ddG, dddG = r["Delta_f"], r["dDelta_f"]
             ddG_list.append(ddG)
             dddG_list.append(dddG)
@@ -287,10 +286,10 @@ def plot_endstate_correction_results(
     ax_index += 1
     axs[ax_index].set_title(rf"{name} - cumulative stddev of W and $\Delta$E")
 
-    if results.W_mm_to_qml.size:
+    if results.W_reference_to_target.size:
         cum_stddev_ws_from_mm_to_qml = [
-            results.W_mm_to_qml[:x].std()
-            for x in range(1, len(results.W_mm_to_qml) + 1)
+            results.W_reference_to_target[:x].std()
+            for x in range(1, len(results.W_reference_to_target) + 1)
         ]
         axs[ax_index].plot(
             cum_stddev_ws_from_mm_to_qml,
@@ -298,10 +297,10 @@ def plot_endstate_correction_results(
             color=c1,
         )
 
-    if results.W_qml_to_mm.size:
+    if results.W_target_to_reference.size:
         cum_stddev_ws_from_qml_to_mm = [
-            results.W_qml_to_mm[:x].std()
-            for x in range(1, len(results.W_qml_to_mm) + 1)
+            results.W_target_to_reference[:x].std()
+            for x in range(1, len(results.W_target_to_reference) + 1)
         ]
         axs[ax_index].plot(
             cum_stddev_ws_from_qml_to_mm,
@@ -309,13 +308,15 @@ def plot_endstate_correction_results(
             color=c3,
         )
 
-    if results.dE_mm_to_qml.size:
-        if results.W_mm_to_qml.size or results.W_qml_to_mm.size:
-            size = max(results.W_mm_to_qml.size, results.W_qml_to_mm.size)
+    if results.dE_reference_to_target.size:
+        if results.W_reference_to_target.size or results.W_target_to_reference.size:
+            size = max(
+                results.W_reference_to_target.size, results.W_target_to_reference.size
+            )
         else:
-            size = results.dE_mm_to_qml.size
+            size = results.dE_reference_to_target.size
         cum_stddev_dEs_from_mm_to_qml = [
-            results.dE_mm_to_qml[:x].std() for x in range(1, size + 1)
+            results.dE_reference_to_target[:x].std() for x in range(1, size + 1)
         ]
         axs[ax_index].plot(
             cum_stddev_dEs_from_mm_to_qml,
@@ -323,13 +324,15 @@ def plot_endstate_correction_results(
             color=c2,
         )
 
-    if results.dE_qml_to_mm.size:
-        if results.W_mm_to_qml.size or results.W_qml_to_mm.size:
-            size = max(results.W_mm_to_qml.size, results.W_qml_to_mm.size)
+    if results.dE_target_to_reference.size:
+        if results.W_reference_to_target.size or results.W_target_to_reference.size:
+            size = max(
+                results.W_reference_to_target.size, results.W_target_to_reference.size
+            )
         else:
-            size = results.dE_mm_to_qml.size
+            size = results.dE_reference_to_target.size
         cum_stddev_dEs_from_qml_to_mm = [
-            results.dE_qml_to_mm[:x].std() for x in range(1, size + 1)
+            results.dE_target_to_reference[:x].std() for x in range(1, size + 1)
         ]
         axs[ax_index].plot(
             cum_stddev_dEs_from_qml_to_mm,
@@ -351,6 +354,7 @@ def plot_endstate_correction_results(
 
 # plotting torsion profiles
 ###########################################################################################################################################################################
+
 
 # generate molecule picture with atom indices
 def save_mol_pic(zinc_id: str, ff: str):
@@ -399,7 +403,6 @@ def save_mol_pic(zinc_id: str, ff: str):
 
 # get indices of dihedral bonds
 def get_indices(rot_bond: int, rot_bond_list: list, bonds: list):
-
     print(f"---------- Investigating bond nr {rot_bond} ----------")
 
     # get indices of both atoms forming an rotatable bond
@@ -412,11 +415,9 @@ def get_indices(rot_bond: int, rot_bond_list: list, bonds: list):
 
     # find neighbors of atoms forming the rotatable bond and add to index list (if heavy atom torsion)
     for bond in bonds:
-
         # get neighbors of atom_1 (of rotatable bond)
         # check, if atom_1 (of rotatable bond) is the first atom in the current bond
         if bond.atom1_index == atom_1_idx:
-
             # make sure, that neighboring atom is not an hydrogen, nor atom_2
             if (
                 not bond.atom2.element.name == "hydrogen"
@@ -426,7 +427,6 @@ def get_indices(rot_bond: int, rot_bond_list: list, bonds: list):
 
         # check, if atom_1 (of rotatable bond) is the second atom in the current bond
         elif bond.atom2_index == atom_1_idx:
-
             # make sure, that neighboring atom is not an hydrogen, nor atom_2
             if (
                 not bond.atom1.element.name == "hydrogen"
@@ -437,7 +437,6 @@ def get_indices(rot_bond: int, rot_bond_list: list, bonds: list):
         # get neighbors of atom_2 (of rotatable bond)
         # check, if atom_2 (of rotatable bond) is the first atom in the current bond
         if bond.atom1_index == atom_2_idx:
-
             # make sure, that neighboring atom is not an hydrogen, nor atom_1
             if (
                 not bond.atom2.element.name == "hydrogen"
@@ -447,7 +446,6 @@ def get_indices(rot_bond: int, rot_bond_list: list, bonds: list):
 
         # check, if atom_2 (of rotatable bond) is the second atom in the current bond
         elif bond.atom2_index == atom_2_idx:
-
             # make sure, that neighboring atom is not an hydrogen, nor atom_1
             if (
                 not bond.atom1.element.name == "hydrogen"
@@ -457,13 +455,11 @@ def get_indices(rot_bond: int, rot_bond_list: list, bonds: list):
 
     # check, if both atoms forming the rotatable bond have neighbors
     if len(neighbors1) > 0 and len(neighbors2) > 0:
-
         # list for final atom indices defining torsion
         indices = [[neighbors1[0], atom_1_idx, atom_2_idx, neighbors2[0]]]
         return indices
 
     else:
-
         print(f"No heavy atom torsions found for bond {rot_bond}")
         indices = []
         return indices
@@ -471,7 +467,6 @@ def get_indices(rot_bond: int, rot_bond_list: list, bonds: list):
 
 # plot torsion profiles
 def visualize_torsion_profile(mol, trajectories: dataclass):
-
     # get all bonds
     bonds = mol.bonds
     # get all rotatable bonds
@@ -494,7 +489,6 @@ def visualize_torsion_profile(mol, trajectories: dataclass):
     plotting = False
 
     for rot_bond in range(len(rot_bond_list)):
-
         # get atom indices of current rotatable bond forming a torsion
         indices = get_indices(
             rot_bond=rot_bond, rot_bond_list=rot_bond_list, bonds=bonds

--- a/endstate_correction/neq.py
+++ b/endstate_correction/neq.py
@@ -7,21 +7,37 @@ from typing import Tuple
 
 import numpy as np
 from openmm import unit
+from openmm.app import Simulation
 from tqdm import tqdm
-
-from endstate_correction.constant import distance_unit, temperature
+from mdtraj import Trajectory
+from endstate_correction.constant import temperature
 from endstate_correction.system import get_positions
 
 
 def perform_switching(
-    sim,
+    sim: Simulation,
     lambdas: list,
-    samples: list,
+    samples: Trajectory,
     nr_of_switches: int = 50,
     save_trajs: bool = False,
     save_endstates: bool = False,
 ) -> Tuple[list, list, list]:
-    """performs NEQ switching using the lambda sheme passed from randomly dranw samples"""
+    """Perform NEQ switching using the provided lambda schema on the passed simulation instance.
+
+    Args:
+        sim (Simulation): simulation instance
+        lambdas (list): list of lambda values
+        samples (Trajectory): samples from which the starting points fo the NEQ switching simulation are drawn
+        nr_of_switches (int, optional): number of switches. Defaults to 50.
+        save_trajs (bool, optional): save switching trajectories. Defaults to False.
+        save_endstates (bool, optional): save endstate of switching trajectory. Defaults to False.
+
+    Raises:
+        RuntimeError: if the number of lambda states is less than 2
+
+    Returns:
+        Tuple[list, list, list]: work values, endstate samples, switching trajectories
+    """
 
     if save_endstates:
         print("Endstate of each switch will be saved.")
@@ -52,7 +68,7 @@ def perform_switching(
             switching_trajectory = []
 
         # select a random sample
-        random_frame = random.randint(0, len(samples.xyz)-1)
+        random_frame = random.randint(0, len(samples.xyz) - 1)
         x = samples.xyz[random_frame]
         if samples.unitcell_lengths is not None:
             box_length = samples.unitcell_lengths[x]

--- a/endstate_correction/neq.py
+++ b/endstate_correction/neq.py
@@ -14,14 +14,15 @@ from endstate_correction.system import get_positions
 
 
 def perform_switching(
-    sim, lambdas: list, 
-    samples: list, 
-    nr_of_switches: int = 50, 
+    sim,
+    lambdas: list,
+    samples: list,
+    nr_of_switches: int = 50,
     save_trajs: bool = False,
-    save_endstates:bool = False,
+    save_endstates: bool = False,
 ) -> Tuple[list, list, list]:
     """performs NEQ switching using the lambda sheme passed from randomly dranw samples"""
-   
+
     if save_endstates:
         print("Endstate of each switch will be saved.")
     if save_trajs:
@@ -48,13 +49,10 @@ def perform_switching(
         if save_trajs:
             # if switching trajectories need to be saved, create an empty list at the beginning
             # of each switch for saving conformations
-            switching_trajectory = [] 
+            switching_trajectory = []
 
         # select a random sample
-        x = (
-            np.array(random.choice(samples).value_in_unit(distance_unit))
-            * distance_unit
-        )
+        x = random.choice(samples.xyz)
         # set position
         sim.context.setPositions(x)
 
@@ -94,11 +92,14 @@ def perform_switching(
             endstate_samples.append(get_positions(sim))
         # get all work values
         ws.append(w)
-    return np.array(ws) * unit.kilojoule_per_mole, endstate_samples, all_switching_trajectories
+    return (
+        np.array(ws) * unit.kilojoule_per_mole,
+        endstate_samples,
+        all_switching_trajectories,
+    )
 
 
 def _collect_work_values(file: str) -> list:
-
     ws = pickle.load(open(file, "rb")).value_in_unit(unit.kilojoule_per_mole)
     number_of_samples = len(ws)
     print(f"Number of samples used: {number_of_samples}")

--- a/endstate_correction/neq.py
+++ b/endstate_correction/neq.py
@@ -52,10 +52,16 @@ def perform_switching(
             switching_trajectory = []
 
         # select a random sample
-        x = random.choice(samples.xyz)
+        random_frame = random.randint(0, len(samples.xyz)-1)
+        x = samples.xyz[random_frame]
+        if samples.unitcell_lengths is not None:
+            box_length = samples.unitcell_lengths[x]
+        else:
+            box_length = None
         # set position
         sim.context.setPositions(x)
-
+        if box_length:
+            sim.context.setPeriodicBoxVectors(*box_length)
         # reseed velocities
         sim.context.setVelocitiesToTemperature(temperature)
         # initialize work

--- a/endstate_correction/neq.py
+++ b/endstate_correction/neq.py
@@ -67,15 +67,16 @@ def perform_switching(
             # of each switch for saving conformations
             switching_trajectory = []
 
-        # select a random sample
-        random_frame = random.randint(0, len(samples.xyz) - 1)
-        x = samples.xyz[random_frame]
+        # select a random frame
+        random_frame_idx = random.randint(0, len(samples.xyz) - 1)
+        # select the coordinates of the random frame
+        coord = samples.xyz[random_frame_idx]
         if samples.unitcell_lengths is not None:
-            box_length = samples.unitcell_lengths[x]
+            box_length = samples.unitcell_lengths[random_frame_idx]
         else:
             box_length = None
         # set position
-        sim.context.setPositions(x)
+        sim.context.setPositions(coord)
         if box_length:
             sim.context.setPeriodicBoxVectors(*box_length)
         # reseed velocities

--- a/endstate_correction/system.py
+++ b/endstate_correction/system.py
@@ -1,15 +1,11 @@
 # general imports
 import json
 
-import openmm as mm
 from openmm import unit
 from openmm.app import (
-    PME,
     CharmmPsfFile,
     CharmmCrdFile,
-    NoCutoff,
 )
-from openmmml import MLPotential
 
 
 def gen_box(psf: CharmmPsfFile, crd: CharmmCrdFile) -> CharmmPsfFile:

--- a/endstate_correction/tests/test_analysis.py
+++ b/endstate_correction/tests/test_analysis.py
@@ -67,9 +67,9 @@ def test_plot_results_for_FEP_protocol():
 
     fep_protocol = Protocol(
         method="FEP",
-        direction="unidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples=qml_samples,
         nr_of_switches=50,
     )
 
@@ -81,9 +81,9 @@ def test_plot_results_for_FEP_protocol():
 
     fep_protocol = Protocol(
         method="FEP",
-        direction="bidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples = qml_samples,
         nr_of_switches=100,
     )
 
@@ -114,9 +114,9 @@ def test_plot_results_for_NEQ_protocol():
 
     fep_protocol = Protocol(
         method="NEQ",
-        direction="unidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples = qml_samples,
         nr_of_switches=100,
     )
 
@@ -131,9 +131,9 @@ def test_plot_results_for_NEQ_protocol():
 
     fep_protocol = Protocol(
         method="NEQ",
-        direction="bidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples=qml_samples,
         nr_of_switches=100,
     )
     # load pregenerated data
@@ -168,9 +168,9 @@ def test_plot_results_for_all_protocol():
 
     fep_protocol = Protocol(
         method="All",
-        direction="bidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples=qml_samples,
         nr_of_switches=100,
     )
 

--- a/endstate_correction/tests/test_analysis.py
+++ b/endstate_correction/tests/test_analysis.py
@@ -4,7 +4,7 @@ import endstate_correction
 from openmm.app import CharmmParameterSet, CharmmPsfFile
 import pytest
 import os
-from .test_system import setup_vacuum_simulation, setup_waterbox_simulation
+from .test_system import setup_vacuum_simulation
 
 @pytest.mark.skipif(
     os.getenv("CI") == "true",

--- a/endstate_correction/tests/test_endstate_correction.py
+++ b/endstate_correction/tests/test_endstate_correction.py
@@ -14,14 +14,14 @@ def test_endstate_correction_imported():
     """Sample test, will always pass so long as import statement worked."""
     assert "endstate_correction" in sys.modules
 
+
 def save_pickle_results(sim, mm_samples, qml_samples, system_name):
-    
     # generate data for plotting tests
     protocol = Protocol(
         method="NEQ",
-        direction="bidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        target_samples=mm_samples,
+        reference_samples=qml_samples,
         nr_of_switches=100,
     )
 
@@ -35,9 +35,9 @@ def save_pickle_results(sim, mm_samples, qml_samples, system_name):
 
     protocol = Protocol(
         method="NEQ",
-        direction="unidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples=qml_samples,
         nr_of_switches=100,
     )
 
@@ -64,31 +64,31 @@ def test_FEP_protocol():
 
     fep_protocol = Protocol(
         method="FEP",
-        direction="unidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
         nr_of_switches=50,
     )
 
     r = perform_endstate_correction(fep_protocol)
-    assert len(r.dE_mm_to_qml) == fep_protocol.nr_of_switches
-    assert len(r.dE_qml_to_mm) == 0
-    assert len(r.W_mm_to_qml) == 0
-    assert len(r.W_qml_to_mm) == 0
+    print(r)
+    assert len(r.dE_reference_to_target) == fep_protocol.nr_of_switches
+    assert len(r.dE_target_to_reference) == 0
+    assert len(r.W_reference_to_target) == 0
+    assert len(r.W_target_to_reference) == 0
 
     fep_protocol = Protocol(
         sim=sim,
         method="FEP",
-        direction="bidirectional",
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples=qml_samples,
         nr_of_switches=50,
     )
 
     r = perform_endstate_correction(fep_protocol)
-    assert len(r.dE_mm_to_qml) == fep_protocol.nr_of_switches
-    assert len(r.dE_qml_to_mm) == fep_protocol.nr_of_switches
-    assert len(r.W_mm_to_qml) == 0
-    assert len(r.W_qml_to_mm) == 0
+    assert len(r.dE_reference_to_target) == fep_protocol.nr_of_switches
+    assert len(r.dE_target_to_reference) == fep_protocol.nr_of_switches
+    assert len(r.W_reference_to_target) == 0
+    assert len(r.W_target_to_reference) == 0
 
 
 @pytest.mark.skipif(
@@ -112,36 +112,35 @@ def test_NEQ_protocol():
 
     protocol = Protocol(
         method="NEQ",
-        direction="unidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples=qml_samples,
         nr_of_switches=10,
         neq_switching_length=50,
     )
 
     r = perform_endstate_correction(protocol)
-    assert len(r.dE_mm_to_qml) == 0
-    assert len(r.dE_qml_to_mm) == 0
-    assert len(r.W_mm_to_qml) == protocol.nr_of_switches
-    assert len(r.W_qml_to_mm) == 0
+    assert len(r.dE_reference_to_target) == 0
+    assert len(r.dE_target_to_reference) == 0
+    assert len(r.W_reference_to_target) == protocol.nr_of_switches
+    assert len(r.W_target_to_reference) == protocol.nr_of_switches
 
     protocol = Protocol(
         method="NEQ",
-        direction="bidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
         nr_of_switches=10,
         neq_switching_length=50,
     )
 
     r = perform_endstate_correction(protocol)
-    assert len(r.dE_mm_to_qml) == 0
-    assert len(r.dE_qml_to_mm) == 0
-    assert len(r.W_mm_to_qml) == protocol.nr_of_switches
-    assert len(r.W_qml_to_mm) == protocol.nr_of_switches
+    assert len(r.dE_reference_to_target) == 0
+    assert len(r.dE_target_to_reference) == 0
+    assert len(r.W_reference_to_target) == protocol.nr_of_switches
+    assert len(r.W_target_to_reference) == 0
 
     # longer NEQ switching
-    #save_pickle_results(sim, mm_samples, qml_samples, system_name)
+    # save_pickle_results(sim, mm_samples, qml_samples, system_name)
 
 
 @pytest.mark.skipif(
@@ -166,24 +165,32 @@ def test_ALL_protocol():
 
     protocol = Protocol(
         method="All",
-        direction="bidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples=qml_samples,
         nr_of_switches=10,
         neq_switching_length=50,
     )
 
     r = perform_endstate_correction(protocol)
-    assert len(r.dE_mm_to_qml) == protocol.nr_of_switches
-    assert len(r.dE_qml_to_mm) == protocol.nr_of_switches
-    assert len(r.W_mm_to_qml) == protocol.nr_of_switches
-    assert len(r.W_qml_to_mm) == protocol.nr_of_switches
+    assert len(r.dE_reference_to_target) == protocol.nr_of_switches
+    assert len(r.dE_target_to_reference) == protocol.nr_of_switches
+    assert len(r.W_reference_to_target) == protocol.nr_of_switches
+    assert len(r.W_target_to_reference) == protocol.nr_of_switches
 
-    assert not np.isclose(r.dE_mm_to_qml[0], r.dE_qml_to_mm[0], rtol=1e-8)
-    assert not np.isclose(r.dE_mm_to_qml[0], r.W_mm_to_qml[0], rtol=1e-8)
-    assert not np.isclose(r.dE_mm_to_qml[0], r.W_qml_to_mm[0], rtol=1e-8)
+    assert not np.isclose(
+        r.dE_reference_to_target[0], r.dE_target_to_reference[0], rtol=1e-8
+    )
+    assert not np.isclose(
+        r.dE_reference_to_target[0], r.W_reference_to_target[0], rtol=1e-8
+    )
+    assert not np.isclose(
+        r.dE_reference_to_target[0], r.W_target_to_reference[0], rtol=1e-8
+    )
 
-    assert not np.isclose(r.W_qml_to_mm[0], r.W_mm_to_qml[0], rtol=1e-8)
+    assert not np.isclose(
+        r.W_target_to_reference[0], r.W_reference_to_target[0], rtol=1e-8
+    )
 
 
 def test_each_protocol():
@@ -197,72 +204,35 @@ def test_each_protocol():
     )
 
     ####################################################
-    # -------------------Nonsense ----------------------
-    ####################################################
-
-    try:
-        fep_protocol = Protocol(
-            method="EQU",
-            direction="unidirectional",
-            sim=sim,
-            trajectories=[mm_samples, qml_samples],
-            nr_of_switches=10,
-        )
-    except AttributeError:
-        pass
-
-    try:
-        fep_protocol = Protocol(
-            method="NEQ",
-            direction="tridirectional",
-            sim=sim,
-            trajectories=[mm_samples, qml_samples],
-            nr_of_switches=10,
-        )
-    except AttributeError:
-        pass
-    try:
-        fep_protocol = Protocol(
-            method="NEQ",
-            direction="bidirectional",
-            sim=sim,
-            trajectories=[mm_samples],
-            nr_of_switches=10,
-        )
-    except AssertionError:
-        pass
-
-    ####################################################
     # ----------------------- FEP ----------------------
     ####################################################
 
     fep_protocol = Protocol(
         method="FEP",
-        direction="unidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
         nr_of_switches=10,
     )
 
     r = perform_endstate_correction(fep_protocol)
-    assert len(r.dE_mm_to_qml) == fep_protocol.nr_of_switches
-    assert len(r.dE_qml_to_mm) == 0
-    assert len(r.W_mm_to_qml) == 0
-    assert len(r.W_qml_to_mm) == 0
+    assert len(r.dE_reference_to_target) == fep_protocol.nr_of_switches
+    assert len(r.dE_target_to_reference) == 0
+    assert len(r.W_reference_to_target) == 0
+    assert len(r.W_target_to_reference) == 0
 
     fep_protocol = Protocol(
-        sim=sim,
         method="FEP",
-        direction="bidirectional",
-        trajectories=[mm_samples, qml_samples],
+        sim=sim,
+        target_samples=mm_samples,
+        reference_samples=qml_samples,
         nr_of_switches=10,
     )
 
     r = perform_endstate_correction(fep_protocol)
-    assert len(r.dE_mm_to_qml) == fep_protocol.nr_of_switches
-    assert len(r.dE_qml_to_mm) == fep_protocol.nr_of_switches
-    assert len(r.W_mm_to_qml) == 0
-    assert len(r.W_qml_to_mm) == 0
+    assert len(r.dE_reference_to_target) == fep_protocol.nr_of_switches
+    assert len(r.dE_target_to_reference) == fep_protocol.nr_of_switches
+    assert len(r.W_reference_to_target) == 0
+    assert len(r.W_target_to_reference) == 0
 
     ####################################################
     # ----------------------- NEQ ----------------------
@@ -270,82 +240,61 @@ def test_each_protocol():
 
     neq_protocol = Protocol(
         method="NEQ",
-        direction="unidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples=qml_samples,
         nr_of_switches=10,
         neq_switching_length=50,
     )
 
     r = perform_endstate_correction(neq_protocol)
-    assert len(r.dE_mm_to_qml) == 0
-    assert len(r.dE_qml_to_mm) == 0
-    assert len(r.W_mm_to_qml) == neq_protocol.nr_of_switches
-    assert len(r.W_qml_to_mm) == 0
-    assert len(r.endstate_samples_mm_to_qml) == 0
-    assert len(r.endstate_samples_qml_to_mm) == 0
-    assert len(r.switching_traj_mm_to_qml) == 0
-    assert len(r.switching_traj_qml_to_mm) == 0
+    assert len(r.dE_reference_to_target) == 0
+    assert len(r.dE_target_to_reference) == 0
+    assert len(r.W_reference_to_target) == neq_protocol.nr_of_switches
+    assert len(r.W_target_to_reference) == neq_protocol.nr_of_switches
+    assert len(r.endstate_samples_reference_to_target) == 0
+    assert len(r.endstate_samples_reference_to_target) == 0
+    assert len(r.switching_traj_reference_to_target) == 0
+    assert len(r.switching_traj_target_to_reference) == 0
 
     neq_protocol = Protocol(
         method="NEQ",
-        direction="unidirectional_reverse",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
         nr_of_switches=10,
         neq_switching_length=50,
     )
 
     r = perform_endstate_correction(neq_protocol)
-    assert len(r.dE_mm_to_qml) == 0
-    assert len(r.dE_qml_to_mm) == 0
-    assert len(r.W_mm_to_qml) == 0
-    assert len(r.W_qml_to_mm) == neq_protocol.nr_of_switches
-    assert len(r.endstate_samples_mm_to_qml) == 0
-    assert len(r.endstate_samples_qml_to_mm) == 0
-    assert len(r.switching_traj_mm_to_qml) == 0
-    assert len(r.switching_traj_qml_to_mm) == 0
-    
+    assert len(r.dE_reference_to_target) == 0
+    assert len(r.dE_target_to_reference) == 0
+    assert len(r.W_reference_to_target) == neq_protocol.nr_of_switches
+    assert len(r.W_target_to_reference) == 0
+    assert len(r.endstate_samples_reference_to_target) == 0
+    assert len(r.endstate_samples_reference_to_target) == 0
+    assert len(r.switching_traj_reference_to_target) == 0
+    assert len(r.switching_traj_target_to_reference) == 0
 
-    neq_protocol = Protocol(
-        sim=sim,
-        method="NEQ",
-        direction="bidirectional",
-        trajectories=[mm_samples, qml_samples],
-        nr_of_switches=10,
-        neq_switching_length=50,
-    )
-
-    r = perform_endstate_correction(neq_protocol)
-    assert len(r.dE_mm_to_qml) == 0
-    assert len(r.dE_qml_to_mm) == 0
-    assert len(r.W_mm_to_qml) == neq_protocol.nr_of_switches
-    assert len(r.W_qml_to_mm) == neq_protocol.nr_of_switches
-    assert len(r.endstate_samples_mm_to_qml) == 0
-    assert len(r.endstate_samples_qml_to_mm) == 0
-    assert len(r.switching_traj_mm_to_qml) == 0
-    assert len(r.switching_traj_qml_to_mm) == 0
-        
     # test saving endstates and saving trajectory option
     protocol = Protocol(
         method="NEQ",
-        direction="bidirectional",
         sim=sim,
-        trajectories=[mm_samples, qml_samples],
+        reference_samples=mm_samples,
+        target_samples=qml_samples,
         nr_of_switches=10,
         neq_switching_length=50,
-        save_endstates = True,
-        save_trajs= True
+        save_endstates=True,
+        save_trajs=True,
     )
 
     r = perform_endstate_correction(protocol)
-    assert len(r.dE_mm_to_qml) == 0
-    assert len(r.dE_qml_to_mm) == 0
-    assert len(r.W_mm_to_qml) == protocol.nr_of_switches
-    assert len(r.W_qml_to_mm) == protocol.nr_of_switches   
-    assert len(r.endstate_samples_mm_to_qml) == protocol.nr_of_switches
-    assert len(r.endstate_samples_qml_to_mm) == protocol.nr_of_switches
-    assert len(r.switching_traj_mm_to_qml) == protocol.nr_of_switches
-    assert len(r.switching_traj_qml_to_mm) == protocol.nr_of_switches
-    assert len(r.switching_traj_mm_to_qml[0]) == protocol.neq_switching_length
-    assert len(r.switching_traj_qml_to_mm[0]) == protocol.neq_switching_length
+    assert len(r.dE_reference_to_target) == 0
+    assert len(r.dE_target_to_reference) == 0
+    assert len(r.W_reference_to_target) == protocol.nr_of_switches
+    assert len(r.W_target_to_reference) == protocol.nr_of_switches
+    assert len(r.endstate_samples_reference_to_target) == protocol.nr_of_switches
+    assert len(r.endstate_samples_reference_to_target) == protocol.nr_of_switches
+    assert len(r.switching_traj_reference_to_target) == protocol.nr_of_switches
+    assert len(r.switching_traj_target_to_reference) == protocol.nr_of_switches
+    assert len(r.switching_traj_reference_to_target[0]) == protocol.neq_switching_length
+    assert len(r.switching_traj_target_to_reference[0]) == protocol.neq_switching_length

--- a/endstate_correction/tests/test_neq.py
+++ b/endstate_correction/tests/test_neq.py
@@ -23,7 +23,6 @@ def test_collect_work_values():
 def load_endstate_system_and_samples(
     system_name: str,
 ) -> Tuple[Simulation, list, list]:
-
     # initialize simulation and load pre-generated samples
 
     from openmm.app import CharmmCrdFile, CharmmParameterSet, CharmmPsfFile
@@ -48,23 +47,22 @@ def load_endstate_system_and_samples(
     n_samples = 5_000
     n_steps_per_sample = 1_000
     ###########################################################################################
-    mm_samples = []
-    xyz, unitcell_lengths, _ = mdtraj.open(
+    pdb_file = f"data/{system_name}/{system_name}.pdb"
+    mm_samples = mdtraj.load_dcd(
         f"data/{system_name}/sampling_charmmff/run01/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_0.0000.dcd",
-    ).read()
+        top=pdb_file,
+    )
 
-    mm_samples.extend(xyz * unit.angstrom)  # NOTE: this is in angstrom!
     qml_samples = []
-    xyz, unitcell_lengths, _ = mdtraj.open(
+    qml_samples = mdtraj.load_dcd(
         f"data/{system_name}/sampling_charmmff/run01/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_1.0000.dcd",
-    ).read()
-    qml_samples.extend(xyz * unit.angstrom)  # NOTE: this is in angstrom!
+        top=pdb_file,
+    )
 
     return sim, mm_samples, qml_samples
 
 
 def test_switching():
-
     system_name = "ZINC00077329"
     print(f"{system_name=}")
 
@@ -97,36 +95,68 @@ def test_switching():
     # perform NEQ switching
     lambs = np.linspace(0, 1, 21)
     dW_forw, _, _ = perform_switching(
-        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1
+        sim, lambdas=lambs, samples=samples_mm, nr_of_switches=2
     )
     print(dW_forw)
+    assert dW_forw[0] != dW_forw[1]
 
     # perform NEQ switching
     lambs = np.linspace(0, 1, 101)
     dW_forw, _, _ = perform_switching(
-        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1
+        sim, lambdas=lambs, samples=samples_mm, nr_of_switches=2
     )
     print(dW_forw)
+    assert dW_forw[0] != dW_forw[1]
 
     # check return values
     lambs = np.linspace(0, 1, 3)
     list_1, list_2, list_3 = perform_switching(
-        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1, save_endstates=False, save_trajs=False
+        sim,
+        lambdas=lambs,
+        samples=samples_mm[:1],
+        nr_of_switches=1,
+        save_endstates=False,
+        save_trajs=False,
     )
     assert len(list_1) == 1 and len(list_2) == 0 and len(list_3) == 0
 
     list_1, list_2, list_3 = perform_switching(
-        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1, save_endstates=False, save_trajs=True
+        sim,
+        lambdas=lambs,
+        samples=samples_mm[:1],
+        nr_of_switches=1,
+        save_endstates=False,
+        save_trajs=True,
     )
 
-    assert len(list_1) == 1 and len(list_2) == 0 and len(list_3) == 1 and len(list_3[0]) == 3
+    assert (
+        len(list_1) == 1
+        and len(list_2) == 0
+        and len(list_3) == 1
+        and len(list_3[0]) == 3
+    )
 
     list_1, list_2, list_3 = perform_switching(
-        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1, save_endstates=True, save_trajs=False
+        sim,
+        lambdas=lambs,
+        samples=samples_mm[:1],
+        nr_of_switches=1,
+        save_endstates=True,
+        save_trajs=False,
     )
     assert len(list_1) == 1 and len(list_2) == 1 and len(list_3) == 0
 
     list_1, list_2, list_3 = perform_switching(
-        sim, lambdas=lambs, samples=samples_mm[:1], nr_of_switches=1, save_endstates=True, save_trajs=True
+        sim,
+        lambdas=lambs,
+        samples=samples_mm[:1],
+        nr_of_switches=1,
+        save_endstates=True,
+        save_trajs=True,
     )
-    assert len(list_1) == 1 and len(list_2) == 1 and len(list_3) == 1 and len(list_3[0]) == 3
+    assert (
+        len(list_1) == 1
+        and len(list_2) == 1
+        and len(list_3) == 1
+        and len(list_3[0]) == 3
+    )

--- a/endstate_correction/tests/test_perform_endstate_correction.py
+++ b/endstate_correction/tests/test_perform_endstate_correction.py
@@ -11,7 +11,7 @@ from endstate_correction.simulation import (
 from endstate_correction.topology import AMBERTopology
 
 
-class TestPerformCorrection():
+class TestPerformCorrection:
     @staticmethod
     @pytest.fixture(scope="module")
     def bss_protocol():
@@ -29,6 +29,7 @@ class TestPerformCorrection():
             lam=pd.Series(data={"ml-lambda": 0}),
         )
         return protocol
+
     @staticmethod
     @pytest.fixture(scope="module")
     def ec(tmp_path_factory, bss_protocol):
@@ -62,9 +63,9 @@ class TestPerformCorrection():
         traj = ec.get_xyz()
         fep_protocol = Protocol(
             method="NEQ",
-            direction="bidirectional",
             sim=sim,
-            trajectories=[traj, traj],
+            reference_samples=traj,
+            target_samples=traj,
             nr_of_switches=5,
             neq_switching_length=10,
         )


### PR DESCRIPTION
## Description

Allow switches starting from pool of conformations that have varying box vectors.
In the process of preparing for these changes we also realized that fields in the result/protocol dataclass don't use clear language to specify the direction of the switching and what pool of samples is used. This is also addressed in this PR.


## Todos
  - [x] change function signature to allow passing of a mdtraj.Trajectory instance from which switches are initialized. This has the benefit that we have access to the unit cell information if needed.
  - [x] update fields in dataclasses to indicate direction of switching and what pool of samples is used 

## Status
- [ ] Ready to go