### PR TITLE
seperate print statment from plotting

### DIFF
--- a/endstate_correction/analysis.py
+++ b/endstate_correction/analysis.py
@@ -86,50 +86,34 @@ def plot_results_for_equilibrium_free_energy(
     plt.close()
 
 
-def plot_endstate_correction_results(
-    name: str, results: Results, filename: str = "plot.png"
-):
+def summarize_endstate_correction_results(results: Results):
     assert type(results) == Results
-
-    multiple_results = 1
-    ax_index = 0
     print("#--------------- SUMMARY ---------------#")
-    ##############################################
-    # ---------------------- FEP ------------------
+
     if results.dE_reference_to_target.size:
         print(
             f"Zwanzig's equation (from mm to qml): {exp(results.dE_reference_to_target)['Delta_f']}"
         )
-        multiple_results += 1
     if results.dE_target_to_reference.size:
         print(
             f"Zwanzig's equation (from qml to mm): {exp(results.dE_target_to_reference)['Delta_f']}"
         )
-        multiple_results += 1
     if results.dE_reference_to_target.size and results.dE_target_to_reference.size:
         print(
             f"Zwanzig's equation bidirectional: {bar(results.dE_reference_to_target, results.dE_target_to_reference)['Delta_f']}"
         )
-        multiple_results += 1
-    ##############################################
-    # ---------------------- NEQ ------------------
     if results.W_reference_to_target.size:
         print(
             f"Jarzynski's equation (from mm to qml): {exp(results.W_reference_to_target)['Delta_f']}"
         )
-        multiple_results += 1
     if results.W_target_to_reference.size:
         print(
             f"Jarzynski's equation (from qml to mm): {exp(results.W_target_to_reference)['Delta_f']}"
         )
-        multiple_results += 1
     if results.W_reference_to_target.size and results.W_target_to_reference.size:
         print(
             f"Crooks' equation: {bar(results.W_reference_to_target, results.W_target_to_reference)['Delta_f']}"
         )
-        multiple_results += 1
-    ##############################################
-    # ---------------------- EQU ------------------
     if results.equ_mbar:
         ddG_equ = np.average(
             [
@@ -144,9 +128,18 @@ def plot_endstate_correction_results(
             ]
         )
         print(f"Equilibrium free energy: {ddG_equ}+/-{dddG_equ}")
-        multiple_results += 1
-    print("#--------------------------------------#")
 
+
+def plot_endstate_correction_results(
+    name: str, results: Results, filename: str = "plot.png"
+):
+    assert type(results) == Results
+
+    multiple_results = [
+        n for n, r in enumerate(results, 1) if r.dE_reference_to_target.size
+    ]
+    ax_index = 0
+    summarize_endstate_correction_results(results)
     ###########################################################
     # ------------------- Plot distributions ------------------
 

--- a/endstate_correction/analysis.py
+++ b/endstate_correction/analysis.py
@@ -13,6 +13,7 @@ from matplotlib.ticker import FormatStrFormatter
 from pymbar import bar, exp
 from endstate_correction.protocol import Results
 from endstate_correction.constant import zinc_systems
+from dataclasses import dataclass, fields
 
 
 def plot_overlap_for_equilibrium_free_energy(
@@ -87,6 +88,12 @@ def plot_results_for_equilibrium_free_energy(
 
 
 def summarize_endstate_correction_results(results: Results):
+    """ Summarize the results of the endstate correction analysis.
+
+    Args:
+        results (Results): instance of the Results class
+    """
+    
     assert type(results) == Results
     print("#--------------- SUMMARY ---------------#")
 
@@ -135,10 +142,19 @@ def plot_endstate_correction_results(
 ):
     assert type(results) == Results
 
-    multiple_results = [
-        n for n, r in enumerate(results, 1) if r.dE_reference_to_target.size
-    ]
+    ###########################################################
+    # count how many results are available
+    multiple_results = 0
+    for field in fields(results):
+        print(field.name, getattr(results, field.name))
+        try:
+            if getattr(results, field.name).size:
+                multiple_results += 1
+        except AttributeError:
+            continue
+        
     ax_index = 0
+    ###########################################################
     summarize_endstate_correction_results(results)
     ###########################################################
     # ------------------- Plot distributions ------------------


### PR DESCRIPTION
## Description

Plotting is nice, but sometimes we only need text output.
This moves the results printing function out from the plotting function so that it can be called separately.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] separate plotting and printing functions


## Status
- [ ] Ready to go