### PR TITLE
Allow EndstateCorrectionAMBER class to run only with CPU

### DIFF
--- a/endstate_correction/simulation/base.py
+++ b/endstate_correction/simulation/base.py
@@ -33,7 +33,7 @@ class EndstateCorrectionBase(abc.ABC):
         name: str = "endstate_correction",
         work_dir: str = "./",
         potential: str = "ani2x",
-        implementation: str = "nnpops",
+        implementation: Literal["nnpops", "torchani"] = "nnpops",
         interpolate: bool = True,
     ):
         self.logger = logging.getLogger("EndstateCorrectionBase")
@@ -52,7 +52,7 @@ class EndstateCorrectionBase(abc.ABC):
             mm_system,
             ml_atoms,
             interpolate=interpolate,
-            implementation="nnpops",
+            implementation=implementation,
         )
         integrator = self.get_integrator()
         platform = get_fastest_platform(minimum_precision="mixed")

--- a/endstate_correction/tests/test_perform_endstate_correction.py
+++ b/endstate_correction/tests/test_perform_endstate_correction.py
@@ -65,6 +65,7 @@ class TestPerformCorrection:
             protocol=bss_protocol,
             name=system_name,
             work_dir=str(output_base),
+            implementation="torchani",
         )
         simulation.set_trajectory(str(parameter_base / f"{system_name}.h5"))
         return simulation


### PR DESCRIPTION
## Description
This fix the bug that the `implementation` given to EndstateCorrectionAMBER is not passed to the system creation.
Modify the test to test the torchani implementation.


## Status
- [x] Ready to go