### PR TITLE
Adjust FEP protocol

### DIFF
--- a/endstate_correction/tests/test_endstate_correction.py
+++ b/endstate_correction/tests/test_endstate_correction.py
@@ -92,6 +92,14 @@ def test_FEP_protocol():
     assert np.all(r_fep.dE_reference_to_target < 0)  # the dE_forw have negative values
     assert np.all(r_fep.dE_target_to_reference > 0)  # the dE_rev have positive values
 
+    # if no specific number of swithes is given, the protocol should take all provided equilibrium samples 
+    fep_protocol = FEPProtocol(
+        sim=sim,
+        reference_samples=mm_samples[:20],
+    )
+    r = perform_endstate_correction(fep_protocol)
+    r_fep = r.fep_results
+    assert len(r_fep.dE_reference_to_target) == 20
 
 @pytest.mark.skipif(
     os.getenv("CI") == "true",

--- a/scripts/perform_correction_hipen.py
+++ b/scripts/perform_correction_hipen.py
@@ -11,7 +11,7 @@ from openmm.app import (
 from endstate_correction.constant import zinc_systems, blacklist
 from endstate_correction.analysis import plot_endstate_correction_results
 import endstate_correction
-from endstate_correction.protocol import perform_endstate_correction, Protocol
+from endstate_correction.protocol import perform_endstate_correction, FEPProtocol, NEQProtocol
 import mdtraj
 from openmm import unit
 import pickle, sys, os
@@ -30,8 +30,7 @@ if system_name in blacklist:
 
 env = "vacuum"
 
-print(system_name)
-print(env)
+print(f"Setting up system {system_name} in {env}")
 
 # define directory containing parameters
 parameter_base = f"{package_path}/data/hipen_data"
@@ -53,13 +52,16 @@ with open("temp.pdb", "w") as outfile:
 chains = list(psf.topology.chains())
 ml_atoms = [atom.index for atom in chains[0].atoms()]
 print(f"{ml_atoms=}")
+print("Creating mm system...")
 mm_system = psf.createSystem(params=params)
 # define system
 potential = MLPotential("ani2x")
+print("Creating mixed system...")
 ml_system = potential.createMixedSystem(
     psf.topology, mm_system, ml_atoms, interpolate=True
 )
 sim = Simulation(psf.topology, ml_system, LangevinIntegrator(300, 1, 0.001))
+print("Creating simulation object...")
 ########################################################
 ########################################################
 # ------------------- load samples --------------------#
@@ -70,71 +72,76 @@ n_steps_per_sample = 1_000
 traj_base = f"/data/shared/projects/endstate_rew/{system_name}/sampling_charmmff/"
 
 # load MM samples
-mm_samples = []
+mm_samples_list = []
 for i in range(1, 4):
     base = f"{traj_base}/run0{i}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_0.0000"
     # if needed, convert pickle file to dcd
     # convert_pickle_to_dcd_file(f"{base}.pickle",psf_file, crd_file, f"{base}.dcd", "temp.pdb")
     traj = mdtraj.load_dcd(
         f"{base}.dcd",
-        top=psf_file,
-    )
-    mm_samples.extend(traj[1000:].xyz * unit.nanometer)  # NOTE: this is in nanometer!
+        top=psf_file, # also possible to use the tmp.pdb
+    )[int((n_samples / 100) * 20):]
+    mm_samples_list.append(traj)
+    
+mm_samples = mdtraj.join(mm_samples_list) #* unit.nanometer
+assert isinstance(mm_samples, mdtraj.Trajectory)
 print(f"Initializing switch from {len(mm_samples)} MM samples")
 
 # load NNP samples
-nnp_samples = []
+nnp_samples_list = []
 for i in range(1, 4):
     base = f"{traj_base}/run0{i}/{system_name}_samples_{n_samples}_steps_{n_steps_per_sample}_lamb_1.0000"
     # if needed, convert pickle file to dcd
     # convert_pickle_to_dcd_file(f"{base}.pickle",psf_file, crd_file, f"{base}.dcd", "temp.pdb")
     traj = mdtraj.load_dcd(
         f"{base}.dcd",
-        top=psf_file,
-    )
-    nnp_samples.extend(traj[1000:].xyz * unit.nanometer)  # NOTE: this is in nanometer!
-print(f"Initializing switch from {len(mm_samples)} NNP samples")
+        top=psf_file, # also possible to use the tmp.pdb
+    )[int((n_samples / 100) * 20):]
+    nnp_samples_list.append(traj)
+    
+nnp_samples = mdtraj.join(nnp_samples_list) #* unit.nanometer
+assert isinstance(nnp_samples, mdtraj.Trajectory)
+print(f"Initializing switch from {len(nnp_samples)} NNP samples")
 
 ########################################################
 ########################################################
 # ----------------- perform correction ----------------#
 
 # define the output directory
-output_base = f"/data/shared/projects/endstate_rew/{system_name}/switching_new/"
+output_base = f"/data/shared/projects/endstate_rew/{system_name}/FEP_v1/"
 os.makedirs(output_base, exist_ok=True)
 
 ####################################################
 # ---------------- FEP protocol --------------------
 ####################################################
-fep_protocol = Protocol(
-    method="FEP",
-    direction="bidirectional",
+fep_protocol = FEPProtocol(
     sim=sim,
-    trajectories=[mm_samples, nnp_samples],
-    nr_of_switches=10,  # 2_000,
+    reference_samples=mm_samples,
+    target_samples=nnp_samples,
+    nr_of_switches=2_000,  # if not provided, the protocol will use all provided equilibrium samples
 )
 
 ####################################################
 # ----------------- NEQ protocol -------------------
 ####################################################
-neq_protocol = Protocol(
-    method="NEQ",
-    direction="bidirectional",
-    sim=sim,
-    trajectories=[mm_samples, nnp_samples],
-    nr_of_switches=3,  # 500,
-    neq_switching_length=5,  # _000,
-    save_endstates=True,
-    save_trajs=True,
-)
+# neq_protocol = Protocol(
+    # sim=sim,
+    # reference_samples=mm_samples,
+    # target_samples=nnp_samples,
+    # nr_of_switches=3,  # 500,
+    # switching_length=5,  # _000,
+    # save_endstates=False,
+    # save_trajs=False,
+# )
 
 # perform correction
 r_fep = perform_endstate_correction(fep_protocol)
-r_neq = perform_endstate_correction(neq_protocol)
+#r_neq = perform_endstate_correction(neq_protocol)
 
 # save fep and neq results in a pickle file
-pickle.dump((r_fep, r_neq), open(f"{output_base}/results.pickle", "wb"))
+#pickle.dump((r_fep, r_neq), open(f"{output_base}/results.pickle", "wb"))
+pickle.dump((r_fep), open(f"{output_base}/fep_results.pickle", "wb"))
 
 # plot results
-plot_endstate_correction_results(system_name, r_fep, f"{output_base}/results_neq.png")
-plot_endstate_correction_results(system_name, r_neq, f"{output_base}/results_neq.png")
+plot_endstate_correction_results(system_name, r_fep, f"{output_base}/results_fep.png")
+#plot_endstate_correction_results(system_name, r_neq, f"{output_base}/results_neq.png")


### PR DESCRIPTION
## Description
Until now we have provided a specific number of switches for running FEP (instantaneous switching) and conformations have been selected randomly from the provided pool of equilibrium samples. In this PR this will be changed:
There is still an option in the FEPProtocol to provide a specific `nr_of_switches`. If this option is chosen, the conformations will be selected randomly. If `nr_of_switches` is not provided, all equilibrium samples (`reference_samples` and/or `target_samples`) will be used for calculating \Delta U.

## Todos
  - [x] adjust the switching procedure in `neq.py`
  - [x] add test
  - [x] adjust switching script for HiPen systems

## Status
- [x] Ready to go