### PR TITLE
Update FEP Protocol

### DIFF
--- a/endstate_correction/neq.py
+++ b/endstate_correction/neq.py
@@ -56,7 +56,9 @@ def perform_switching(
         inst_switching = True
         if nr_of_switches == -1: # if no specific nr_of_switches is provided (-1 is the default value), use all provided equilibrium samples
             nr_of_switches = len(samples)
-            print(f"{nr_of_switches} dE values will be calculated")
+            print(f"{nr_of_switches} dE values will be calculated using all provided equilibrium samples")
+        else:
+            print(f"{nr_of_switches} dE values will be calculated using {nr_of_switches} random equilibrium samples")
     elif len(lambdas) < 2:
         raise RuntimeError("increase the number of lambda states")
     else:

--- a/endstate_correction/protocol.py
+++ b/endstate_correction/protocol.py
@@ -224,12 +224,6 @@ class NEQResults(BaseResults):
     endstate_samples_target_to_reference: np.array = field(
         default_factory=lambda: np.array([])
     )  # endstate samples from target to reference
-    switching_traj_reference_to_target: np.array = field(
-        default_factory=lambda: np.array([])
-    )  # switching traj from reference to target
-    switching_traj_target_to_reference: np.array = field(
-        default_factory=lambda: np.array([])
-    )  # switching traj from target to reference
 
 
 @dataclass

--- a/endstate_correction/tests/test_endstate_correction.py
+++ b/endstate_correction/tests/test_endstate_correction.py
@@ -335,8 +335,6 @@ def test_each_protocol():
     assert len(r.neq_results.W_target_to_reference) == 0
     assert len(r.neq_results.endstate_samples_reference_to_target) == 0
     assert len(r.neq_results.endstate_samples_reference_to_target) == 0
-    assert len(r.neq_results.switching_traj_reference_to_target) == 0
-    assert len(r.neq_results.switching_traj_target_to_reference) == 0
     assert r.equ_results == None
 
     neq_protocol = NEQProtocol(
@@ -353,11 +351,18 @@ def test_each_protocol():
     assert len(r.neq_results.W_target_to_reference) == neq_protocol.nr_of_switches
     assert len(r.neq_results.endstate_samples_reference_to_target) == 0
     assert len(r.neq_results.endstate_samples_reference_to_target) == 0
-    assert len(r.neq_results.switching_traj_reference_to_target) == 0
-    assert len(r.neq_results.switching_traj_target_to_reference) == 0
     assert r.equ_results == None
 
-    # test saving endstates and saving trajectory option
+    # if no specific number of swithes is given, the protocol should take all provided equilibrium samples 
+    fep_protocol = FEPProtocol(
+        sim=sim,
+        reference_samples=mm_samples[:20],
+    )
+    r = perform_endstate_correction(fep_protocol)
+    r_fep = r.fep_results
+    assert len(r_fep.dE_reference_to_target) == 20
+
+    # test saving endstates option
     protocol = NEQProtocol(
         sim=sim,
         reference_samples=mm_samples,


### PR DESCRIPTION
## Description
Until now we have provided a specific number of switches for running FEP (instantaneous switching) and conformations have been selected randomly from the provided pool of equilibrium samples. In this PR this will be changed:
There is still an option in the FEPProtocol to provide a specific `nr_of_switches`. If this option is chosen, the conformations will be selected randomly. If `nr_of_switches` is not provided, all equilibrium samples (`reference_samples` and/or `target_samples`) will be used for calculating \Delta U.

## Todos
  - [x] adjust the switching procedure in `neq.py`
  - [x] add test
  - [x] adjust switching script for HiPen systems

## Status
- [x] Ready to go